### PR TITLE
The default of SETTINGS_MAX_CONCURRENT_STREAMS is unlimited 

### DIFF
--- a/src/net/http/h2_bundle.go
+++ b/src/net/http/h2_bundle.go
@@ -3044,6 +3044,7 @@ func (s *http2Server) ServeConn(c net.Conn, opts *http2ServeConnOpts) {
 		serveG:            http2newGoroutineLock(),
 		pushEnabled:       true,
 		pushStreamID:      0,
+		clientMaxStreams:  100,
 	}
 
 	sc.flow.add(http2initialWindowSize)


### PR DESCRIPTION
Set it to 100 instead 0