### PR TITLE
crypto/tls: Fix an error in generate_cert.go

### DIFF
--- a/src/crypto/tls/generate_cert.go
+++ b/src/crypto/tls/generate_cert.go
@@ -10,7 +10,7 @@
 package main
 
 import (
-	cirlSign "circl/sign"
+	circlSchemes "circl/sign/schemes"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
@@ -66,7 +66,7 @@ func main() {
 		if *ed25519Key {
 			_, priv, err = ed25519.GenerateKey(rand.Reader)
 		} else if *circlKey != "" {
-			scheme := circlSign.SchemeByName(*circlKey)
+			scheme := circlSchemes.ByName(*circlKey)
 			if scheme == nil {
 				log.Fatalf("No such Circl scheme: %s", scheme)
 			}


### PR DESCRIPTION
The API call for resolving the CIRCL signature scheme was incorrect.
