### PR TITLE
crypto/tls: Improve ECH metrics collection

### DIFF
--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -116,8 +116,9 @@ type Conn struct {
 	tmp [16]byte
 
 	ech struct {
-		status       ECHStatus
 		offered      bool
+		greased      bool
+		accepted     bool
 		retryConfigs []byte // The retry configurations
 		hrrPsk       []byte // The HRR pre-shared key, used in case of HRR.
 
@@ -711,22 +712,11 @@ func (c *Conn) readRecordOrCCS(expectChangeCipherSpec bool) error {
 			return c.in.setErrorLocked(io.EOF)
 		}
 		if c.vers == VersionTLS13 {
-			if st := c.ech.status; !c.isClient && st != ECHStatusAccepted {
-				// Resolve the status of ECH usage. If ECH was not accepted,
-				// then the server does not know whether the client offered ECH
-				// or sent a dummy ECH extension until the client explicitly
-				// signals rejection.
+			if !c.isClient && c.ech.greased && alert(data[1]) == alertECHRequired {
+				// This condition indicates that the client intended to offer
+				// ECH, but did not use a known ECH config.
 				c.ech.offered = true
-				if len(c.ech.retryConfigs) > 0 {
-					// If retry configurations were sent, then the status is
-					// "ECH rejection".
-					c.ech.status = ECHStatusRejected
-				} else {
-					// If no retry configurations were sent, then the server is
-					// regarded as having disabled ECH. The status is "ECH
-					// bypassed".
-					c.ech.status = ECHStatusBypassed
-				}
+				c.ech.greased = false
 			}
 			return c.in.setErrorLocked(&net.OpError{Op: "remote error", Err: alert(data[1])})
 		}
@@ -1344,6 +1334,29 @@ func (c *Conn) Close() error {
 	if err := c.conn.Close(); err != nil {
 		return err
 	}
+
+	// Resolve ECH status.
+	if !c.isClient && c.config.MaxVersion < VersionTLS13 {
+		c.handleEvent(EXP_EventECHServerStatus(echStatusBypassed))
+	} else if !c.ech.offered {
+		if !c.ech.greased {
+			c.handleEvent(EXP_EventECHClientStatus(echStatusBypassed))
+		} else {
+			c.handleEvent(EXP_EventECHClientStatus(echStatusOuter))
+		}
+	} else {
+		c.handleEvent(EXP_EventECHClientStatus(echStatusInner))
+		if !c.ech.accepted {
+			if len(c.ech.retryConfigs) > 0 {
+				c.handleEvent(EXP_EventECHServerStatus(echStatusOuter))
+			} else {
+				c.handleEvent(EXP_EventECHServerStatus(echStatusBypassed))
+			}
+		} else {
+			c.handleEvent(EXP_EventECHServerStatus(echStatusInner))
+		}
+	}
+
 	return alertErr
 }
 
@@ -1441,8 +1454,6 @@ func (c *Conn) connectionStateLocked() ConnectionState {
 	} else {
 		state.ekm = c.ekm
 	}
-	state.ECHOffered = c.ech.offered
-	state.ECHStatus = c.ech.status
 	return state
 }
 
@@ -1475,4 +1486,10 @@ func (c *Conn) VerifyHostname(host string) error {
 
 func (c *Conn) handshakeComplete() bool {
 	return atomic.LoadUint32(&c.handshakeStatus) == 1
+}
+
+func (c *Conn) handleEvent(event EXP_Event) {
+	if c.config.EXP_EventHandler != nil {
+		c.config.EXP_EventHandler(event)
+	}
 }

--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -157,7 +157,7 @@ func (c *Conn) clientHandshake() (err error) {
 		return err
 	}
 
-	hello, helloInner, err := c.echOfferOrBypass(helloBase)
+	hello, helloInner, err := c.echOfferOrGrease(helloBase)
 	if err != nil {
 		return err
 	}
@@ -856,7 +856,7 @@ func (c *Conn) verifyServerCertificate(certificates [][]byte) error {
 
 	if !c.config.InsecureSkipVerify {
 		dnsName := c.config.ServerName
-		if c.ech.offered && c.ech.status != ECHStatusAccepted {
+		if c.ech.offered && !c.ech.accepted {
 			dnsName = c.serverName
 		}
 		opts := x509.VerifyOptions{

--- a/src/crypto/tls/tls_cf.go
+++ b/src/crypto/tls/tls_cf.go
@@ -45,3 +45,11 @@ func init() {
 			SignatureScheme(cs.scheme.(circlPki.TLSScheme).TLSIdentifier()))
 	}
 }
+
+// EXP_Event is a value emitted at various points in the handshake that is
+// handled by the callback Config.EventHandler.
+//
+// NOTE: This API is EXPERIMENTAL and subject to change.
+type EXP_Event interface {
+	Name() string
+}

--- a/src/crypto/tls/tls_test.go
+++ b/src/crypto/tls/tls_test.go
@@ -790,7 +790,7 @@ func TestCloneNonFuncFields(t *testing.T) {
 		switch fn := typ.Field(i).Name; fn {
 		case "Rand":
 			f.Set(reflect.ValueOf(io.Reader(os.Stdin)))
-		case "Time", "GetCertificate", "GetConfigForClient", "VerifyPeerCertificate", "VerifyConnection", "GetClientCertificate", "ServerECHProvider":
+		case "Time", "GetCertificate", "GetConfigForClient", "VerifyPeerCertificate", "VerifyConnection", "GetClientCertificate", "ServerECHProvider", "EXP_EventHandler":
 			// DeepEqual can't compare functions. If you add a
 			// function field to this list, you must also change
 			// TestCloneFuncFields to ensure that the func field is


### PR DESCRIPTION
* Removes `ECHStatus` and `ECHOffered` from `ConnectionState`.

* Adds a callback `EventHandler()` to `Config`, which can be called at
various points during the handshake to respond to various events. For
example, this callback can be used to record metrics.

* Adds calls to `EventHandler()` just before closing the TLS connection
for resolving ECH usage: whether the client offered, greased, or
bypassed ECH; and whether the server accepted, rejected, or bypassed
ECH.