### PR TITLE
Add experimental handshake timings API

### DIFF
--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -140,6 +140,8 @@ func (c *Conn) clientHandshake() (err error) {
 		c.config = defaultConfig()
 	}
 
+	handshakeTimings := createTLS13ClientHandshakeTimingInfo(c.config.Time)
+
 	// This may be a renegotiation handshake, in which case some fields
 	// need to be reset.
 	c.didResume = false
@@ -186,6 +188,8 @@ func (c *Conn) clientHandshake() (err error) {
 		return err
 	}
 
+	handshakeTimings.WriteClientHello = handshakeTimings.elapsedTime()
+
 	msg, err := c.readHandshake()
 	if err != nil {
 		return err
@@ -215,15 +219,16 @@ func (c *Conn) clientHandshake() (err error) {
 
 	if c.vers == VersionTLS13 {
 		hs := &clientHandshakeStateTLS13{
-			c:           c,
-			serverHello: serverHello,
-			hello:       hello,
-			helloInner:  helloInner,
-			helloBase:   helloBase,
-			ecdheParams: ecdheParams,
-			session:     session,
-			earlySecret: earlySecret,
-			binderKey:   binderKey,
+			c:                c,
+			serverHello:      serverHello,
+			hello:            hello,
+			helloInner:       helloInner,
+			helloBase:        helloBase,
+			ecdheParams:      ecdheParams,
+			session:          session,
+			earlySecret:      earlySecret,
+			binderKey:        binderKey,
+			handshakeTimings: handshakeTimings,
 		}
 
 		// In TLS 1.3, session tickets are delivered after the handshake.

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -17,7 +17,7 @@ import (
 )
 
 // EXP_EventTLS13ClientHandshakeTimingInfo carries intra-stack time durations
-// for state machine changes. It can be used for tracking metrics during a
+// for TLS 1.3 state machine changes. It can be used for tracking metrics during a
 // connection. Some durations may be sensitive, such as the amount of time to
 // process a particular handshake message, so this event should only be used
 // for experimental purposes.
@@ -27,7 +27,7 @@ type EXP_EventTLS13ClientHandshakeTimingInfo struct {
 	timer                   func() time.Time
 	start                   time.Time
 	WriteClientHello        time.Duration
-	ReadServerHello         time.Duration
+	ProcessServerHello      time.Duration
 	ReadEncryptedExtensions time.Duration
 	ReadCertificate         time.Duration
 	ReadCertificateVerify   time.Duration
@@ -389,7 +389,7 @@ func (hs *clientHandshakeStateTLS13) processServerHello() error {
 	c := hs.c
 
 	defer func() {
-		hs.handshakeTimings.ReadServerHello = hs.handshakeTimings.elapsedTime()
+		hs.handshakeTimings.ProcessServerHello = hs.handshakeTimings.elapsedTime()
 	}()
 
 	if bytes.Equal(hs.serverHello.random, helloRetryRequestRandom) {

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -16,9 +16,11 @@ import (
 	"time"
 )
 
-// EXP_EventTLS13ClientHandshakeTimingInfo carries intra-stack durations for
-// state machine changes. It can be used for tracking metrics during a
-// connection.
+// EXP_EventTLS13ClientHandshakeTimingInfo carries intra-stack time durations
+// for state machine changes. It can be used for tracking metrics during a
+// connection. Some durations may be sensitive, such as the amount of time to
+// process a particular handshake message, so this event should only be used
+// for experimental purposes.
 //
 // NOTE: This API is EXPERIMENTAL and subject to change.
 type EXP_EventTLS13ClientHandshakeTimingInfo struct {

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -16,6 +16,46 @@ import (
 	"time"
 )
 
+// EXP_EventTLS13ClientHandshakeTimingInfo carries intra-stack durations for
+// state machine changes. It can be used for tracking metrics during a
+// connection.
+//
+// NOTE: This API is EXPERIMENTAL and subject to change.
+type EXP_EventTLS13ClientHandshakeTimingInfo struct {
+	timer                   func() time.Time
+	start                   time.Time
+	WriteClientHello        time.Duration
+	ReadServerHello         time.Duration
+	ReadEncryptedExtensions time.Duration
+	ReadCertificate         time.Duration
+	ReadCertificateVerify   time.Duration
+	ReadServerFinished      time.Duration
+	WriteCertificate        time.Duration
+	WriteCertificateVerify  time.Duration
+	WriteClientFinished     time.Duration
+}
+
+// Name is required by the EXP_Event interface.
+func (e EXP_EventTLS13ClientHandshakeTimingInfo) Name() string {
+	return "TLS13ClientHandshakeTimingInfo"
+}
+
+func (e EXP_EventTLS13ClientHandshakeTimingInfo) elapsedTime() time.Duration {
+	return time.Now().Sub(e.start)
+}
+
+func createTLS13ClientHandshakeTimingInfo(timerFunc func() time.Time) EXP_EventTLS13ClientHandshakeTimingInfo {
+	timer := time.Now
+	if timerFunc != nil {
+		timer = timerFunc
+	}
+
+	return EXP_EventTLS13ClientHandshakeTimingInfo{
+		timer: timer,
+		start: timer(),
+	}
+}
+
 type clientHandshakeStateTLS13 struct {
 	c           *Conn
 	serverHello *serverHelloMsg
@@ -36,6 +76,8 @@ type clientHandshakeStateTLS13 struct {
 	transcriptInner hash.Hash
 	masterSecret    []byte
 	trafficSecret   []byte // client_application_traffic_secret_0
+
+	handshakeTimings EXP_EventTLS13ClientHandshakeTimingInfo
 }
 
 // handshake requires hs.c, hs.hello, hs.serverHello, hs.ecdheParams, and,
@@ -132,6 +174,7 @@ func (hs *clientHandshakeStateTLS13) handshake() error {
 		return err
 	}
 
+	c.handleEvent(hs.handshakeTimings)
 	atomic.StoreUint32(&c.handshakeStatus, 1)
 
 	return nil
@@ -343,6 +386,10 @@ func (hs *clientHandshakeStateTLS13) processHelloRetryRequest() error {
 func (hs *clientHandshakeStateTLS13) processServerHello() error {
 	c := hs.c
 
+	defer func() {
+		hs.handshakeTimings.ReadServerHello = hs.handshakeTimings.elapsedTime()
+	}()
+
 	if bytes.Equal(hs.serverHello.random, helloRetryRequestRandom) {
 		c.sendAlert(alertUnexpectedMessage)
 		return errors.New("tls: server sent two HelloRetryRequest messages")
@@ -469,6 +516,8 @@ func (hs *clientHandshakeStateTLS13) readServerParameters() error {
 		}
 	}
 
+	hs.handshakeTimings.ReadEncryptedExtensions = hs.handshakeTimings.elapsedTime()
+
 	return nil
 }
 
@@ -518,6 +567,8 @@ func (hs *clientHandshakeStateTLS13) readServerCertificate() error {
 	}
 	hs.transcript.Write(certMsg.marshal())
 
+	hs.handshakeTimings.ReadCertificate = hs.handshakeTimings.elapsedTime()
+
 	c.scts = certMsg.certificate.SignedCertificateTimestamps
 	c.ocspResponse = certMsg.certificate.OCSPStaple
 
@@ -558,6 +609,8 @@ func (hs *clientHandshakeStateTLS13) readServerCertificate() error {
 
 	hs.transcript.Write(certVerify.marshal())
 
+	hs.handshakeTimings.ReadCertificateVerify = hs.handshakeTimings.elapsedTime()
+
 	return nil
 }
 
@@ -574,6 +627,8 @@ func (hs *clientHandshakeStateTLS13) readServerFinished() error {
 		c.sendAlert(alertUnexpectedMessage)
 		return unexpectedMessageError(finished, msg)
 	}
+
+	hs.handshakeTimings.ReadServerFinished = hs.handshakeTimings.elapsedTime()
 
 	expectedMAC := hs.suite.finishedHash(c.in.trafficSecret, hs.transcript)
 	if !hmac.Equal(expectedMAC, finished.verifyData) {
@@ -634,6 +689,8 @@ func (hs *clientHandshakeStateTLS13) sendClientCertificate() error {
 		return err
 	}
 
+	hs.handshakeTimings.WriteCertificate = hs.handshakeTimings.elapsedTime()
+
 	// If we sent an empty certificate message, skip the CertificateVerify.
 	if len(cert.Certificate) == 0 {
 		return nil
@@ -672,6 +729,8 @@ func (hs *clientHandshakeStateTLS13) sendClientCertificate() error {
 		return err
 	}
 
+	hs.handshakeTimings.WriteCertificateVerify = hs.handshakeTimings.elapsedTime()
+
 	return nil
 }
 
@@ -686,6 +745,8 @@ func (hs *clientHandshakeStateTLS13) sendClientFinished() error {
 	if _, err := c.writeRecord(recordTypeHandshake, finished.marshal()); err != nil {
 		return err
 	}
+
+	hs.handshakeTimings.WriteClientFinished = hs.handshakeTimings.elapsedTime()
 
 	c.out.setTrafficSecret(hs.suite, hs.trafficSecret)
 

--- a/src/crypto/tls/handshake_server.go
+++ b/src/crypto/tls/handshake_server.go
@@ -46,8 +46,9 @@ func (c *Conn) serverHandshake() error {
 
 	if c.vers == VersionTLS13 {
 		hs := serverHandshakeStateTLS13{
-			c:           c,
-			clientHello: clientHello,
+			c:                c,
+			clientHello:      clientHello,
+			handshakeTimings: createTLS13ServerHandshakeTimingInfo(c.config.Time),
 		}
 		return hs.handshake()
 	}

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -22,9 +22,11 @@ import (
 // messages cause too much work in session ticket decryption attempts.
 const maxClientPSKIdentities = 5
 
-// EXP_EventTLS13ServerHandshakeTimingInfo carries intra-stack durations for
-// state machine changes. It can be used for tracking metrics during a
-// connection.
+// EXP_EventTLS13ServerHandshakeTimingInfo carries intra-stack time durations
+// for state machine changes. It can be used for tracking metrics during a
+// connection. Some durations may be sensitive, such as the amount of time to
+// process a particular handshake message, so this event should only be used
+// for experimental purposes.
 //
 // NOTE: This API is EXPERIMENTAL and subject to change.
 type EXP_EventTLS13ServerHandshakeTimingInfo struct {

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -22,6 +22,46 @@ import (
 // messages cause too much work in session ticket decryption attempts.
 const maxClientPSKIdentities = 5
 
+// EXP_EventTLS13ServerHandshakeTimingInfo carries intra-stack durations for
+// state machine changes. It can be used for tracking metrics during a
+// connection.
+//
+// NOTE: This API is EXPERIMENTAL and subject to change.
+type EXP_EventTLS13ServerHandshakeTimingInfo struct {
+	timer                    func() time.Time
+	start                    time.Time
+	ReadClientHello          time.Duration
+	WriteServerHello         time.Duration
+	WriteEncryptedExtensions time.Duration
+	WriteCertificate         time.Duration
+	WriteCertificateVerify   time.Duration
+	WriteServerFinished      time.Duration
+	ReadCertificate          time.Duration
+	ReadCertificateVerify    time.Duration
+	ReadClientFinished       time.Duration
+}
+
+// Name is required by the EXP_Event interface.
+func (e EXP_EventTLS13ServerHandshakeTimingInfo) Name() string {
+	return "TLS13ServerHandshakeTimingInfo"
+}
+
+func (e EXP_EventTLS13ServerHandshakeTimingInfo) elapsedTime() time.Duration {
+	return e.timer().Sub(e.start)
+}
+
+func createTLS13ServerHandshakeTimingInfo(timerFunc func() time.Time) EXP_EventTLS13ServerHandshakeTimingInfo {
+	timer := time.Now
+	if timerFunc != nil {
+		timer = timerFunc
+	}
+
+	return EXP_EventTLS13ServerHandshakeTimingInfo{
+		timer: timer,
+		start: timer(),
+	}
+}
+
 type serverHandshakeStateTLS13 struct {
 	c               *Conn
 	clientHello     *clientHelloMsg
@@ -38,6 +78,8 @@ type serverHandshakeStateTLS13 struct {
 	trafficSecret   []byte // client_application_traffic_secret_0
 	transcript      hash.Hash
 	clientFinished  []byte
+
+	handshakeTimings EXP_EventTLS13ServerHandshakeTimingInfo
 }
 
 func (hs *serverHandshakeStateTLS13) handshake() error {
@@ -76,6 +118,7 @@ func (hs *serverHandshakeStateTLS13) handshake() error {
 		return err
 	}
 
+	c.handleEvent(hs.handshakeTimings)
 	atomic.StoreUint32(&c.handshakeStatus, 1)
 
 	return nil
@@ -248,6 +291,9 @@ GroupSelection:
 	}
 
 	c.serverName = hs.clientHello.serverName
+
+	hs.handshakeTimings.ReadClientHello = hs.handshakeTimings.elapsedTime()
+
 	return nil
 }
 
@@ -564,6 +610,8 @@ func (hs *serverHandshakeStateTLS13) sendServerParameters() error {
 		return err
 	}
 
+	hs.handshakeTimings.WriteServerHello = hs.handshakeTimings.elapsedTime()
+
 	if err := hs.sendDummyChangeCipherSpec(); err != nil {
 		return err
 	}
@@ -611,6 +659,8 @@ func (hs *serverHandshakeStateTLS13) sendServerParameters() error {
 		return err
 	}
 
+	hs.handshakeTimings.WriteEncryptedExtensions = hs.handshakeTimings.elapsedTime()
+
 	return nil
 }
 
@@ -653,6 +703,8 @@ func (hs *serverHandshakeStateTLS13) sendServerCertificate() error {
 		return err
 	}
 
+	hs.handshakeTimings.WriteCertificate = hs.handshakeTimings.elapsedTime()
+
 	certVerifyMsg := new(certificateVerifyMsg)
 	certVerifyMsg.hasSignatureAlgorithm = true
 	certVerifyMsg.signatureAlgorithm = hs.sigAlg
@@ -685,6 +737,8 @@ func (hs *serverHandshakeStateTLS13) sendServerCertificate() error {
 		return err
 	}
 
+	hs.handshakeTimings.WriteCertificateVerify = hs.handshakeTimings.elapsedTime()
+
 	return nil
 }
 
@@ -699,6 +753,8 @@ func (hs *serverHandshakeStateTLS13) sendServerFinished() error {
 	if _, err := c.writeRecord(recordTypeHandshake, finished.marshal()); err != nil {
 		return err
 	}
+
+	hs.handshakeTimings.WriteServerFinished = hs.handshakeTimings.elapsedTime()
 
 	// Derive secrets that take context through the server Finished.
 
@@ -837,6 +893,8 @@ func (hs *serverHandshakeStateTLS13) readClientCertificate() error {
 		}
 	}
 
+	hs.handshakeTimings.ReadCertificate = hs.handshakeTimings.elapsedTime()
+
 	if len(certMsg.certificate.Certificate) != 0 {
 		msg, err = c.readHandshake()
 		if err != nil {
@@ -872,6 +930,8 @@ func (hs *serverHandshakeStateTLS13) readClientCertificate() error {
 		hs.transcript.Write(certVerify.marshal())
 	}
 
+	hs.handshakeTimings.ReadCertificateVerify = hs.handshakeTimings.elapsedTime()
+
 	// If we waited until the client certificates to send session tickets, we
 	// are ready to do it now.
 	if err := hs.sendSessionTickets(); err != nil {
@@ -899,6 +959,8 @@ func (hs *serverHandshakeStateTLS13) readClientFinished() error {
 		c.sendAlert(alertDecryptError)
 		return errors.New("tls: invalid client finished hash")
 	}
+
+	hs.handshakeTimings.ReadClientFinished = hs.handshakeTimings.elapsedTime()
 
 	c.in.setTrafficSecret(hs.suite, hs.trafficSecret)
 

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -23,7 +23,7 @@ import (
 const maxClientPSKIdentities = 5
 
 // EXP_EventTLS13ServerHandshakeTimingInfo carries intra-stack time durations
-// for state machine changes. It can be used for tracking metrics during a
+// for TLS 1.3 state machine changes. It can be used for tracking metrics during a
 // connection. Some durations may be sensitive, such as the amount of time to
 // process a particular handshake message, so this event should only be used
 // for experimental purposes.
@@ -32,7 +32,7 @@ const maxClientPSKIdentities = 5
 type EXP_EventTLS13ServerHandshakeTimingInfo struct {
 	timer                    func() time.Time
 	start                    time.Time
-	ReadClientHello          time.Duration
+	ProcessClientHello       time.Duration
 	WriteServerHello         time.Duration
 	WriteEncryptedExtensions time.Duration
 	WriteCertificate         time.Duration
@@ -294,7 +294,7 @@ GroupSelection:
 
 	c.serverName = hs.clientHello.serverName
 
-	hs.handshakeTimings.ReadClientHello = hs.handshakeTimings.elapsedTime()
+	hs.handshakeTimings.ProcessClientHello = hs.handshakeTimings.elapsedTime()
 
 	return nil
 }

--- a/src/crypto/tls/metrics_test.go
+++ b/src/crypto/tls/metrics_test.go
@@ -1,0 +1,132 @@
+// Copyright 2020 Cloudflare, Inc. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+package tls
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+)
+
+type testTimingInfo struct {
+	serverTimingInfo EXP_EventTLS13ServerHandshakeTimingInfo
+	clientTimingInfo EXP_EventTLS13ClientHandshakeTimingInfo
+}
+
+func (t testTimingInfo) isMonotonicallyIncreasing() bool {
+	serverIsMonotonicallyIncreasing :=
+		t.serverTimingInfo.ReadClientHello < t.serverTimingInfo.WriteServerHello &&
+			t.serverTimingInfo.WriteServerHello < t.serverTimingInfo.WriteEncryptedExtensions &&
+			t.serverTimingInfo.WriteEncryptedExtensions < t.serverTimingInfo.WriteCertificate &&
+			t.serverTimingInfo.WriteCertificate < t.serverTimingInfo.WriteCertificateVerify &&
+			t.serverTimingInfo.WriteCertificateVerify < t.serverTimingInfo.WriteServerFinished &&
+			t.serverTimingInfo.WriteServerFinished < t.serverTimingInfo.ReadCertificate &&
+			t.serverTimingInfo.ReadCertificate < t.serverTimingInfo.ReadCertificateVerify &&
+			t.serverTimingInfo.ReadCertificateVerify < t.serverTimingInfo.ReadClientFinished
+
+	clientIsMonotonicallyIncreasing :=
+		t.clientTimingInfo.WriteClientHello < t.clientTimingInfo.ReadServerHello &&
+			t.clientTimingInfo.ReadServerHello < t.clientTimingInfo.ReadEncryptedExtensions &&
+			t.clientTimingInfo.ReadEncryptedExtensions < t.clientTimingInfo.ReadCertificate &&
+			t.clientTimingInfo.ReadCertificate < t.clientTimingInfo.ReadCertificateVerify &&
+			t.clientTimingInfo.ReadCertificateVerify < t.clientTimingInfo.ReadServerFinished &&
+			t.clientTimingInfo.ReadServerFinished < t.clientTimingInfo.WriteCertificate &&
+			t.clientTimingInfo.WriteCertificate < t.clientTimingInfo.WriteCertificateVerify &&
+			t.clientTimingInfo.WriteCertificateVerify < t.clientTimingInfo.WriteClientFinished
+
+	return (serverIsMonotonicallyIncreasing && clientIsMonotonicallyIncreasing)
+}
+
+func (r *testTimingInfo) eventHandler(event EXP_Event) {
+	switch e := event.(type) {
+	case EXP_EventTLS13ServerHandshakeTimingInfo:
+		r.serverTimingInfo = e
+	case EXP_EventTLS13ClientHandshakeTimingInfo:
+		r.clientTimingInfo = e
+	}
+}
+
+func runHandshake(t *testing.T, clientConfig, serverConfig *Config) (timingState testTimingInfo, err error) {
+	const sentinel = "SENTINEL\n"
+	c, s := localPipe(t)
+	errChan := make(chan error)
+
+	clientConfig.EXP_EventHandler = timingState.eventHandler
+	serverConfig.EXP_EventHandler = timingState.eventHandler
+
+	go func() {
+		cli := Client(c, clientConfig)
+		err := cli.Handshake()
+		if err != nil {
+			errChan <- fmt.Errorf("client: %v", err)
+			c.Close()
+			return
+		}
+		defer cli.Close()
+		buf, err := ioutil.ReadAll(cli)
+		if err != nil {
+			t.Errorf("failed to call cli.Read: %v", err)
+		}
+		if got := string(buf); got != sentinel {
+			t.Errorf("read %q from TLS connection, but expected %q", got, sentinel)
+		}
+		errChan <- nil
+	}()
+
+	server := Server(s, serverConfig)
+	err = server.Handshake()
+	if err == nil {
+		if _, err := io.WriteString(server, sentinel); err != nil {
+			t.Errorf("failed to call server.Write: %v", err)
+		}
+		if err := server.Close(); err != nil {
+			t.Errorf("failed to call server.Close: %v", err)
+		}
+		err = <-errChan
+	} else {
+		s.Close()
+		<-errChan
+	}
+
+	return
+}
+
+func TestTLS13HandshakeTiming(t *testing.T) {
+	issuer, err := x509.ParseCertificate(testRSACertificateIssuer)
+	if err != nil {
+		panic(err)
+	}
+	rootCAs := x509.NewCertPool()
+	rootCAs.AddCert(issuer)
+
+	const serverName = "example.golang"
+
+	baseConfig := &Config{
+		Time:         time.Now,
+		Rand:         zeroSource{},
+		Certificates: make([]Certificate, 1),
+		MaxVersion:   VersionTLS13,
+		RootCAs:      rootCAs,
+		ClientCAs:    rootCAs,
+		ClientAuth:   RequireAndVerifyClientCert,
+		ServerName:   serverName,
+	}
+	baseConfig.Certificates[0].Certificate = [][]byte{testRSACertificate}
+	baseConfig.Certificates[0].PrivateKey = testRSAPrivateKey
+
+	clientConfig := baseConfig.Clone()
+	serverConfig := baseConfig.Clone()
+
+	ts, err := runHandshake(t, clientConfig, serverConfig)
+	if err != nil {
+		t.Fatalf("Handshake failed: %v", err)
+	}
+
+	if !ts.isMonotonicallyIncreasing() {
+		t.Fatalf("Timing information is not monotonic")
+	}
+}

--- a/src/crypto/tls/metrics_test.go
+++ b/src/crypto/tls/metrics_test.go
@@ -19,7 +19,7 @@ type testTimingInfo struct {
 
 func (t testTimingInfo) isMonotonicallyIncreasing() bool {
 	serverIsMonotonicallyIncreasing :=
-		t.serverTimingInfo.ReadClientHello < t.serverTimingInfo.WriteServerHello &&
+		t.serverTimingInfo.ProcessClientHello < t.serverTimingInfo.WriteServerHello &&
 			t.serverTimingInfo.WriteServerHello < t.serverTimingInfo.WriteEncryptedExtensions &&
 			t.serverTimingInfo.WriteEncryptedExtensions < t.serverTimingInfo.WriteCertificate &&
 			t.serverTimingInfo.WriteCertificate < t.serverTimingInfo.WriteCertificateVerify &&
@@ -29,8 +29,8 @@ func (t testTimingInfo) isMonotonicallyIncreasing() bool {
 			t.serverTimingInfo.ReadCertificateVerify < t.serverTimingInfo.ReadClientFinished
 
 	clientIsMonotonicallyIncreasing :=
-		t.clientTimingInfo.WriteClientHello < t.clientTimingInfo.ReadServerHello &&
-			t.clientTimingInfo.ReadServerHello < t.clientTimingInfo.ReadEncryptedExtensions &&
+		t.clientTimingInfo.WriteClientHello < t.clientTimingInfo.ProcessServerHello &&
+			t.clientTimingInfo.ProcessServerHello < t.clientTimingInfo.ReadEncryptedExtensions &&
 			t.clientTimingInfo.ReadEncryptedExtensions < t.clientTimingInfo.ReadCertificate &&
 			t.clientTimingInfo.ReadCertificate < t.clientTimingInfo.ReadCertificateVerify &&
 			t.clientTimingInfo.ReadCertificateVerify < t.clientTimingInfo.ReadServerFinished &&


### PR DESCRIPTION
The basic idea here is as follows:

Extend the experimental event (`EXP_Event`) interface to cover "handshake timing info" events, which tracks relevant timestamps for important events in the TLS 1.3 state machine. Applications that wish to use these timestamps to track metrics, such as total handshake latency from CH...SFIN.

For example, applications might wire up an event handler to collect this timing information and use it as needed:

~~~go
// ... modified from metrics_test.go ...

func (r *testTimingInfo) eventHandler(event EXP_Event) {
	switch e := event.(type) {
	case EXP_EventTLS13ServerHandshakeTimingInfo:
		// use e's server timestamps as needed
	case EXP_EventTLS13ClientHandshakeTimingInfo:
		// use e's client timestamps as needed
	}
}

config := tls.Config{
   EXP_EventHandler: eventHandler
} 

// run TLS connection with `config`
}
~~~
