### PR TITLE
crypto/tls: Move draft-ietf-tls-esni-08 to -09

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -100,8 +100,9 @@ const (
 	extensionSignatureAlgorithmsCert uint16 = 50
 	extensionKeyShare                uint16 = 51
 	extensionRenegotiationInfo       uint16 = 0xff01
-	extensionECH                     uint16 = 0xfe08 // draft-ietf-tls-esni-08
-	extensionECHOuterExtensions      uint16 = 0xfd00 // draft-ietf-tls-esni-08
+	extensionECH                     uint16 = 0xfe09 // draft-ietf-tls-esni-09
+	extensionECHIsInner              uint16 = 0xda09 // draft-ietf-tls-esni-09
+	extensionECHOuterExtensions      uint16 = 0xfd00 // draft-ietf-tls-esni-09
 )
 
 // TLS signaling cipher suite values
@@ -248,6 +249,14 @@ var testingECHOuterExtNone bool
 // "outer_extension" extension in the wrong order when offering the ECH
 // extension.
 var testingECHOuterExtIncorrectOrder bool
+
+// testingECHOuterIsInner causes the client to send the "ech_is_inner" extension
+// in the ClientHelloOuter.
+var testingECHOuterIsInner bool
+
+// testingECHOuterExtIllegal causes the client to send in its
+// "outer_extension" extension the codepoint for the ECH extension.
+var testingECHOuterExtIllegal bool
 
 // ConnectionState records basic TLS details about the connection.
 type ConnectionState struct {
@@ -729,7 +738,7 @@ type Config struct {
 	// ServerECHProvider is the ECH provider used by the client-facing server
 	// for the ECH extension. If the client offers ECH and TLS 1.3 is
 	// negotiated, then the provider is used to compute the HPKE context
-	// (draft-irtf-cfrg-hpke-05), which in turn is used to decrypt the extension
+	// (draft-irtf-cfrg-hpke-07), which in turn is used to decrypt the extension
 	// payload.
 	ServerECHProvider ECHProvider
 

--- a/src/crypto/tls/ech.go
+++ b/src/crypto/tls/ech.go
@@ -4,8 +4,7 @@
 package tls
 
 import (
-	"bytes"
-	"crypto/tls/internal/hpke"
+	"circl/hpke"
 	"errors"
 	"fmt"
 	"io"
@@ -15,15 +14,11 @@ import (
 
 const (
 	// Constants for TLS operations
-	echTls13LabelAcceptConfirm = "ech accept confirmation"
+	echAcceptConfirmationLabel = "ech accept confirmation"
 
 	// Constants for HPKE operations
-	echHpkeInfoInnerDigest = "tls ech inner digest"
-	echHpkeInfoConfigId    = "tls ech config id"
-	echHpkeInfoSetup       = "tls ech"
-	echHpkeHrrKeyExporter  = "tls ech hrr key"
-	echHpkeHrrKeyId        = "hrr key"
-	echHpkeHrrKeyLen       = 32
+	echHpkeInfoConfigId = "tls ech config id"
+	echHpkeInfoSetup    = "tls ech"
 
 	// Constants for ECH status events
 	echStatusBypassed = 1 + iota
@@ -83,20 +78,24 @@ func (e EXP_EventECHServerStatus) Name() string {
 	return "ech server status"
 }
 
-// A dummy client-facing server public key used to generate covertext for the
-// ECH extension. This is a random 32-byte string, which will be interpreted as
-// an X25519 public key.
-var echDummyX25519PublicKey = []byte{
-	143, 38, 37, 36, 12, 6, 229, 30, 140, 27, 167, 73, 26, 100, 203, 107, 216,
-	81, 163, 222, 52, 211, 54, 210, 46, 37, 78, 216, 157, 97, 241, 244,
+// EXP_EventECHPublicNameMismatch is emitted if the outer SNI does not match
+// match the public name of the ECH configuration. Note that we do not record
+// the outer SNI in order to avoid collecting this potentially sensitive data.
+//
+// NOTE: This API is EXPERIMENTAL and subject to change.
+type EXP_EventECHPublicNameMismatch struct{}
+
+// Name is required by the EXP_Event interface.
+func (e EXP_EventECHPublicNameMismatch) Name() string {
+	return "ech public name does not match outer sni"
 }
 
 // TODO(cjpatton): "[When offering ECH, the client] MUST NOT offer to resume any
 // session for TLS 1.2 and below [in ClientHelloInner]."
 //
 // TODO(cjpatton): "[When offering ECH, the client] MUST NOT include the
-// "pre_shared_key" extension [in ClientHelloOuter]." This is a "don't stick
-// out" issue.
+// "pre_shared_key" extension [in ClientHelloOuter]." (This is a "don't stick
+// out" issue.)
 //
 // TODO(cjpatton): Implement client-side padding.
 func (c *Conn) echOfferOrGrease(helloBase *clientHelloMsg) (hello, helloInner *clientHelloMsg, err error) {
@@ -105,456 +104,300 @@ func (c *Conn) echOfferOrGrease(helloBase *clientHelloMsg) (hello, helloInner *c
 	if !config.ECHEnabled ||
 		(c.hrrTriggered && testingECHTriggerBypassAfterHRR) ||
 		(!c.hrrTriggered && testingECHTriggerBypassBeforeHRR) {
-		// Bypass ECH without providing covertext.
+		// Bypass ECH.
 		return helloBase, nil, nil
 	}
 
-	// Decide whether to offer the ECH extension in this connection, If offered,
-	// then hello is set to the ClientHelloOuter and helloInner is set to the
-	// ClientHelloInner.
-	if echConfig := config.echSelectConfig(); echConfig != nil &&
-		config.maxSupportedVersion() >= VersionTLS13 {
-
-		// Construct the ClientHelloInner.
-		//
-		// Make a copy of helloBase, add an empty ECH extension, and generate a
-		// fresh random value.
-		helloInner = new(clientHelloMsg)
-		*helloInner = *helloBase
-
-		// Set "encrypted_client_hello" with an empty payload.
-		helloInner.encryptedClientHelloOffered = true
-
-		// Ensure that only TLS 1.3 and above are offered.
-		if v := helloInner.supportedVersions; v[len(v)-1] < VersionTLS13 {
-			return nil, nil, errors.New("tls: ech: TLS 1.3 required")
-		}
-
-		// Set "random".
-		if len(c.ech.hrrInnerRandom) == 0 {
-			// Generate a fresh "random".
-			helloInner.random = make([]byte, 32)
-			_, err := io.ReadFull(config.rand(), helloInner.random)
+	echConfig := config.echSelectConfig()
+	if echConfig == nil || config.maxSupportedVersion() < VersionTLS13 {
+		// Compute artifacts that are reused across HRR.
+		if c.ech.dummy == nil {
+			// Serialized ClientECH.
+			c.ech.dummy, err = echGenerateDummyExt(config.rand())
 			if err != nil {
-				return nil, nil, errors.New("tls: short read from Rand: " + err.Error())
+				return nil, nil, fmt.Errorf("tls: ech: failed to generate grease ECH: %s", err)
 			}
-		} else {
-			// After HRR, use the "random" sent in the first ClientHelloInner.
-			helloInner.random = c.ech.hrrInnerRandom
 		}
 
-		// Construct the EncodedClientHelloInner.
-		//
-		// NOTE(cjpatton): It would be nice to incorporate more extensions, but
-		// "key_share" is the last extension to appear in the ClientHello before
-		// "pre_shared_key". As a result, the only contiguous sequence of outer
-		// extensions that contains "key_share" is "key_share" itself. Note that
-		// we cannot change the order of extensions in the ClientHello, as the
-		// unit tests expect "key_share" to be second to last extension.
-		outerExtensions := []uint16{extensionKeyShare}
-		if testingECHOuterExtMany {
-			// NOTE(cjpatton): Incorporating this particular sequence does not
-			// yield significant savings. However, it's useful to test that our
-			// server correctly handles a sequence of compressed extensions and
-			// not just one.
-			outerExtensions = []uint16{
-				extensionStatusRequest,
-				extensionSupportedCurves,
-				extensionSupportedPoints,
-			}
-		} else if testingECHOuterExtNone {
-			outerExtensions = nil
-		}
-		encodedHelloInner, ok := echEncodeClientHelloInner(helloInner.marshal(), outerExtensions)
-		if !ok {
-			return nil, nil, errors.New("tls: ech: encoding of EncodedClientHelloInner failed")
-		}
-
-		// Construct the ClientHelloOuter.
-		//
-		// Generate a fresh ClientHello, but replace "key_share" and "random",
-		// and "session_id" with the values generated for helloBase and set
-		// "server_name" to be the client-facing server.
-		hello, _, err = c.makeClientHello(config.MinVersion)
-		if err != nil {
-			return nil, nil, fmt.Errorf("tls: ech: %s", err)
-		}
-
-		// Set "random".
-		hello.random = helloBase.random
-
-		// Set "session_id" to be the same as ClientHelloInner.
-		hello.sessionId = helloBase.sessionId
-
-		// Set "key_share" to the same as ClientHelloInner.
-		hello.keyShares = helloBase.keyShares
-
-		// Set "server_name" to be the client-facing server.
-		hello.serverName = hostnameInSNI(string(echConfig.rawPublicName))
-
-		// Encrypt EncodedClientHelloInner.
-		//
-		// AEAD encryption authenticates the ClientHelloOuter sans the
-		// "encrypted_client_hello" extension.
-		helloOuterAad := hello.marshal()
-
-		// Prepare the encryption context. Note that c.ech.hrrPsk is initially
-		// nil, meaning no PSK is used for encrypting the first ClientHelloInner
-		// in case of HRR.
-		ctx, enc, err := echConfig.setupClientContext(c.ech.hrrPsk, config.rand())
-		if err != nil {
-			return nil, nil, fmt.Errorf("tls: ech: %s", err)
-		}
-
-		// Finish ClientHelloOuter.
-		var ech echClient
-		ech.handle.suite = ctx.cipherSuite()
-		ech.handle.configId = ctx.configId(echConfig.raw)
-		ech.handle.enc = enc
-		ech.payload = ctx.seal(helloOuterAad, encodedHelloInner)
-		if testingECHTriggerPayloadDecryptError {
-			// Send inauthentic payload.
-			ech.payload[0] ^= 0xff
-		}
-		hello.encryptedClientHelloOffered = true
-		hello.encryptedClientHello = ech.marshal()
-
-		// Update the HRR pre-shared-key. This is used to encrypt the second
-		// ClientHelloInner in case the server sends an HRR.
-		c.ech.hrrPsk = ctx.hrrPsk()
-
-		// Record the "random" sent in the ClientHelloInner. This value will be
-		// used for the second ClientHelloInner in case the server sends an HRR.
-		c.ech.hrrInnerRandom = helloInner.random
-
-		// Offer ECH.
-		c.ech.offered = true
-		helloInner.raw = nil
-		hello.raw = nil
-		return hello, helloInner, nil
+		// Grease ECH.
+		helloBase.ech = c.ech.dummy
+		helloBase.echIsOuter = true
+		c.ech.offered = false
+		c.ech.greased = true
+		helloBase.raw = nil
+		return helloBase, nil, nil
 	}
 
-	hello = new(clientHelloMsg)
-	*hello = *helloBase
+	// Compute artifacts that are reused across HRR.
+	var enc, configId []byte
+	if c.ech.sealer == nil {
+		// HPKE context.
+		enc, c.ech.sealer, err = echConfig.setupSealer(config.rand())
+		if err != nil {
+			return nil, nil, fmt.Errorf("tls: ech: %s", err)
+		}
 
-	// Produce covertext for the ECH extension.
+		// ClientECH.config_id.
+		_, kdfId, _ := c.ech.sealer.Suite().Params()
+		configId, err = echConfig.id(kdfId)
+		if err != nil {
+			return nil, nil, fmt.Errorf("tls: ech: %s", err)
+		}
+
+		// ECHConfig.contents.public_name.
+		c.ech.publicName = string(echConfig.rawPublicName)
+
+		// ClientHelloInner.random.
+		c.ech.innerRandom = make([]byte, 32)
+		if _, err = io.ReadFull(config.rand(), c.ech.innerRandom); err != nil {
+			return nil, nil, fmt.Errorf("tls: short read from Rand: %s", err)
+		}
+	}
+
+	// ClientHelloInner is constructed from helloBase, but uses a fresh "random"
+	// (helloBase.random is used for ClientHelloOuter) and an empty
+	// "ech_is_inner" extension indicating that this is the ClientHelloInner.
+	helloInner = new(clientHelloMsg)
+	*helloInner = *helloBase
+	helloInner.random = c.ech.innerRandom
+	helloInner.echIsInner = true
+
+	// Ensure that only TLS 1.3 and above are offered.
+	if v := helloInner.supportedVersions; len(v) == 0 || v[len(v)-1] < VersionTLS13 {
+		return nil, nil, errors.New("tls: ech: only TLS 1.3 is allowed in ClientHelloInner")
+	}
+
+	// EncodedClientHelloInner is constructed from ClientHelloInner by removing
+	// extensions that are also used in the ClientHelloOuter.
 	//
-	// Using a hard-coded KEM public key, generate a fresh encapsulated key
-	// "enc". Generate a random "config_id" and "payload" of appropriate length.
-	hpkeSuite, err := hpkeAssembleCipherSuite(dummyKemId, dummyKdfId, dummyAeadId)
-	if err != nil {
-		return nil, nil, fmt.Errorf("tls: ech covertext: %s", err)
-	}
-	pk, err := hpkeSuite.KEM.Deserialize(echDummyX25519PublicKey)
-	if err != nil {
-		return nil, nil, fmt.Errorf("tls: ech covertext: %s", err)
-	}
-
-	// Compute the dummy context handle ("cipher_suite", "config_id", and
-	// "enc").
-	var dummyEch echClient
-	dummyEch.handle.suite.kdfId = dummyKdfId
-	dummyEch.handle.suite.aeadId = dummyAeadId
-	if !c.hrrTriggered {
-		dummyEch.handle.configId = make([]byte, dummyKdfOutputLen)
-		if _, err = io.ReadFull(config.rand(), dummyEch.handle.configId); err != nil {
-			return nil, nil, fmt.Errorf("tls: ech covertext: %s", err)
+	// NOTE(cjpatton): It would be nice to incorporate more extensions, but
+	// "key_share" is the last extension to appear in the ClientHello before
+	// "pre_shared_key". As a result, the only contiguous sequence of outer
+	// extensions that contains "key_share" is "key_share" itself. Note that
+	// we cannot change the order of extensions in the ClientHello, as the
+	// unit tests expect "key_share" to be the second to last extension.
+	outerExtensions := []uint16{extensionKeyShare}
+	if testingECHOuterExtMany {
+		// NOTE(cjpatton): Incorporating this particular sequence does not
+		// yield significant savings. However, it's useful to test that our
+		// server correctly handles a sequence of compressed extensions and
+		// not just one.
+		outerExtensions = []uint16{
+			extensionStatusRequest,
+			extensionSupportedCurves,
+			extensionSupportedPoints,
 		}
-		c.ech.hrrConfigId = dummyEch.handle.configId
-	} else {
-		// After HRR, the server checks these fields match.
-		dummyEch.handle.configId = c.ech.hrrConfigId
+	} else if testingECHOuterExtNone {
+		outerExtensions = nil
 	}
-	dummyEch.handle.enc, _, err = hpke.SetupBaseS(hpkeSuite, config.rand(), pk, nil)
+	encodedHelloInner := echEncodeClientHelloInner(helloInner.marshal(), outerExtensions)
+	if encodedHelloInner == nil {
+		return nil, nil, errors.New("tls: ech: encoding of EncodedClientHelloInner failed")
+	}
+
+	// ClientHelloOuter is constructed by generating a fresh ClientHello and
+	// copying "key_share", "random", and "sesion_id" from helloBase, setting
+	// "server_name" to be the client-facing server, and adding the
+	// "encrypted_client_hello" extension.
+	hello, _, err = c.makeClientHello(config.MinVersion)
 	if err != nil {
-		return nil, nil, fmt.Errorf("tls: ech covertext: %s", err)
+		return nil, nil, fmt.Errorf("tls: ech: %s", err)
+	}
+	hello.keyShares = helloBase.keyShares
+	hello.random = helloBase.random
+	hello.sessionId = helloBase.sessionId
+	hello.serverName = hostnameInSNI(c.ech.publicName)
+	hello.echIsOuter = true
+	if testingECHOuterIsInner {
+		hello.echIsInner = true
 	}
 
-	// Compute the dummy "payload".
-	dummyEncodedHelloInnerLen := 100 // TODO(cjpatton): Compute this correctly.
-	dummyEch.payload = make([]byte, dummyEncodedHelloInnerLen+dummyAeadOverheadLen)
-	if _, err = io.ReadFull(config.rand(), dummyEch.payload); err != nil {
-		return nil, nil, fmt.Errorf("tls: ech covertext: %s", err)
+	// ClientECH, the payload of the "encrypted_client_hello" extension.
+	var ech echClient
+	_, kdfId, aeadId := c.ech.sealer.Suite().Params()
+	ech.handle.suite.kdfId = uint16(kdfId)
+	ech.handle.suite.aeadId = uint16(aeadId)
+	ech.handle.configId = configId // Empty after HRR
+	ech.handle.enc = enc           // Empty after HRR
+	helloOuterAad := echEncodeClientHelloOuterAAD(hello.marshal(), ech.handle.marshal())
+	if helloOuterAad == nil {
+		return nil, nil, errors.New("tls: ech: encoding of ClientHelloOuterAAD failed")
 	}
+	ech.payload, err = c.ech.sealer.Seal(encodedHelloInner, helloOuterAad)
+	if err != nil {
+		return nil, nil, fmt.Errorf("tls: ech: seal failed: %s", err)
+	}
+	if testingECHTriggerPayloadDecryptError {
+		ech.payload[0] ^= 0xff // Inauthentic ciphertext
+	}
+	hello.ech = ech.marshal()
 
-	// Add the dummy ECH extension to the ClientHello.
-	hello.encryptedClientHelloOffered = true
-	hello.encryptedClientHello = dummyEch.marshal()
-
-	// Bypass ECH and provide covertext.
-	c.ech.offered = false
-	c.ech.greased = true
+	// Offer ECH.
+	c.ech.offered = true
+	helloInner.raw = nil
 	hello.raw = nil
-	return hello, nil, nil
+	return hello, helloInner, nil
 }
 
-func (c *Conn) echAcceptOrBypass(hello *clientHelloMsg) (*clientHelloMsg, error) {
+func (c *Conn) echAcceptOrReject(hello *clientHelloMsg) (*clientHelloMsg, error) {
 	config := c.config
-	echProvider := config.ServerECHProvider
+	p := config.ServerECHProvider
 
-	// Decide whether to bypass ECH.
-	echSentBeforeHrr := c.ech.offered || c.ech.greased
-	if !config.echCanAccept() ||
-		!hello.encryptedClientHelloOffered ||
-		len(hello.encryptedClientHello) == 0 {
-		if c.hrrTriggered && echSentBeforeHrr {
-			// Detect illegal second ClientHello.
-			c.sendAlert(alertIllegalParameter)
-			return nil, errors.New("ech: hrr: bypass after offer")
-		}
-
+	if !config.echCanAccept() {
 		// Bypass ECH.
 		return hello, nil
 	}
 
-	if c.hrrTriggered && !echSentBeforeHrr {
-		// Detect illegal second ClientHello.
-		c.sendAlert(alertIllegalParameter)
-		return nil, errors.New("ech: hrr: offer after bypass")
-	}
-
-	// Parse the payload of the ECH extension.
-	ech, err := echUnmarshalClient(hello.encryptedClientHello)
-	if err != nil {
-		c.sendAlert(alertIllegalParameter)
-		return nil, fmt.Errorf("ech: %s", err)
-	}
-
-	if c.hrrTriggered && !bytes.Equal(ech.handle.configId, c.ech.hrrConfigId) {
-		// Detect illegal second ClientHello
-		c.sendAlert(alertIllegalParameter)
-		return nil, errors.New("ech: hrr: illegal handle in second ClientHello")
-	}
-	c.ech.hrrConfigId = ech.handle.configId
-
-	// Ask the ECH provider for the decryption context. Note that c.ech.hrrPsk
-	// is initially nil, meaning no PSK is used for encrypting the first
-	// ClientHelloInner.
-	res := echProvider.GetContext(ech.handle.marshal(), c.ech.hrrPsk, extensionECH)
-	reject := func() (*clientHelloMsg, error) {
-		if c.hrrTriggered && c.ech.accepted {
-			// ECH was accepted prior to HRR then rejected after. Because the
-			// configuration identifier is the same in the first ClientHello as
-			// it is in the second, this indicates a server failure, likely due
-			// to the ECH key being rotated.
-			c.sendAlert(alertInternalError)
-			return nil, errors.New("ech: hrr: reject after accept")
+	if hello.echIsInner {
+		if hello.echIsOuter {
+			c.sendAlert(alertIllegalParameter)
+			return hello, errors.New("ech: hello marked as inner and outer")
 		}
-
-		// Presume the client sent a dummy extension until we have information
-		// to the contrary. We won't know whether the client intended to offer
-		// ECH unless it sends an "ech_required" alert.
-		c.ech.greased = true
-
-		// Send retry configs just in case our presumption is wrong and the
-		// client intended to offer ECH.
-		c.ech.retryConfigs = res.RetryConfigs
-
-		// Proceed with ClientHelloOuter.
+		if len(hello.ech) > 0 {
+			c.sendAlert(alertIllegalParameter)
+			return hello, errors.New("ech_is_inner: got non-empty payload")
+		}
+		// Bypass ECH and continue as backend server.
 		return hello, nil
 	}
 
-	if res.Status == ECHProviderAbort {
-		if alert := alert(res.Alert); alert == alertIllegalParameter {
-			// This alert signals that the context handle sent by the client is
-			// malformed. An abort here would stick out, so reject instead.
-			return reject()
-		} else {
-			c.sendAlert(alert)
+	if !hello.echIsOuter {
+		if c.ech.offered {
+			// This occurs if the server accepted prior to HRR, but the client
+			// failed to send the ECH extension in the second ClientHelloOuter. This
+			// would cause ClientHelloOuter to be used after ClientHelloInner, which
+			// is illegal.
+			c.sendAlert(alertMissingExtension)
+			return nil, errors.New("ech: hrr: bypass after offer")
+		}
+		// Bypass ECH.
+		return hello, nil
+	}
+
+	if c.hrrTriggered && !c.ech.offered && !c.ech.greased {
+		// The client bypassed ECH prior to HRR, but not after. This could
+		// cause ClientHelloInner to be used after ClientHelloOuter, which is
+		// illegal.
+		c.sendAlert(alertIllegalParameter)
+		return nil, errors.New("ech: hrr: offer or grease after bypass")
+	}
+
+	// Parse ClientECH.
+	ech, err := echUnmarshalClient(hello.ech)
+	if err != nil {
+		c.sendAlert(alertIllegalParameter)
+		return nil, fmt.Errorf("ech: failed to parse extension: %s", err)
+	}
+	if c.hrrTriggered && c.ech.offered &&
+		(ech.handle.suite != c.ech.suite ||
+			len(ech.handle.configId) > 0 ||
+			len(ech.handle.enc) > 0) {
+		// The context handle shouldn't change across HRR.
+		c.sendAlert(alertIllegalParameter)
+		return nil, errors.New("ech: hrr: illegal handle in second hello")
+	}
+	c.ech.suite = ech.handle.suite
+
+	// Ask the ECH provider for the HPKE context.
+	if c.ech.opener == nil {
+		res := p.GetDecryptionContext(ech.handle.marshal(), extensionECH)
+
+		// Compute retry configurations, skipping those indicating an
+		// unsupported version.
+		if len(res.RetryConfigs) > 0 {
+			configs, err := UnmarshalECHConfigs(res.RetryConfigs)
+			if err != nil {
+				c.sendAlert(alertInternalError)
+				return nil, fmt.Errorf("ech: %s", err)
+			}
+
+			if len(configs) > 0 {
+				c.ech.retryConfigs, err = echMarshalConfigs(configs)
+				if err != nil {
+					c.sendAlert(alertInternalError)
+					return nil, fmt.Errorf("ech: %s", err)
+				}
+			}
+
+			// Check if the outer SNI matches the public name of any ECH config
+			// advertised by the client-facing server. As of
+			// draft-ietf-tls-esni-09, the client is required to use the ECH
+			// config's public name as the outer SNI. Although there's no real
+			// reason for the server to enforce this, it worth noting it when it
+			// happens.
+			pubNameMatches := false
+			for _, config := range configs {
+				if hello.serverName == string(config.rawPublicName) {
+					pubNameMatches = true
+				}
+			}
+			if !pubNameMatches {
+				c.handleEvent(EXP_EventECHPublicNameMismatch{})
+			}
+		}
+
+		switch res.Status {
+		case ECHProviderSuccess:
+			c.ech.opener, err = hpke.UnmarshalOpener(res.Context)
+			if err != nil {
+				c.sendAlert(alertInternalError)
+				return nil, fmt.Errorf("ech: %s", err)
+			}
+		case ECHProviderReject:
+			// Reject ECH. We do not know at this point whether the client
+			// intended to offer or grease ECH, so we presume grease until the
+			// client indicates rejection by sending an "ech_required" alert.
+			c.ech.greased = true
+			return hello, nil
+		case ECHProviderAbort:
+			c.sendAlert(alert(res.Alert))
 			return nil, fmt.Errorf("ech: %s", err)
+		default:
+			c.sendAlert(alertInternalError)
+			return nil, errors.New("ech: unexpected provider status")
 		}
 	}
 
-	if res.Status == ECHProviderReject {
-		// Reject ECH.
-		return reject()
-	}
-
-	if res.Status != ECHProviderSuccess {
-		// This shouldn't happen.
-		c.sendAlert(alertInternalError)
-		return nil, errors.New("ech: expected success")
-	}
-
-	ctx, err := echUnmarshalServerContext(res.Context)
-	if err != nil {
-		c.sendAlert(alertInternalError)
-		return nil, fmt.Errorf("ech: %s", err)
-	}
-
-	helloOuterAad, ok := encodeClientHelloOuterAAD(hello.raw, extensionECH)
-	if !ok {
+	// EncodedClientHelloInner, the plaintext corresponding to
+	// ClientECH.payload.
+	helloOuterAad := echEncodeClientHelloOuterAAD(hello.marshal(), ech.handle.marshal())
+	if helloOuterAad == nil {
 		// This occurs if the ClientHelloOuter is malformed. This values was
 		// already parsed into `hello`, so this should not happen.
 		c.sendAlert(alertInternalError)
-		return nil, fmt.Errorf("ech: failed to compute ClientHelloOuterAAD")
+		return nil, fmt.Errorf("ech: failed to encode ClientHelloOuterAAD")
 	}
-
-	rawEncodedHelloInner, err := ctx.open(helloOuterAad, ech.payload)
+	rawEncodedHelloInner, err := c.ech.opener.Open(ech.payload, helloOuterAad)
 	if err != nil {
 		if c.hrrTriggered && c.ech.accepted {
 			// Don't reject after accept, as this would result in processing the
 			// ClientHelloOuter after processing the ClientHelloInner.
 			c.sendAlert(alertDecryptError)
-			return nil, fmt.Errorf("ech: hrr: decryption failure after acceptance: %s", err)
+			return nil, fmt.Errorf("ech: hrr: reject after accept: %s", err)
 		}
-
-		// Reject ECH.
-		return reject()
+		// Reject ECH. We do not know at this point whether the client
+		// intended to offer or grease ECH, so we presume grease until the
+		// client indicates rejection by sending an "ech_required" alert.
+		c.ech.greased = true
+		return hello, nil
 	}
 
-	rawHelloInner, ok := echDecodeClientHelloInner(rawEncodedHelloInner, hello.marshal(), hello.sessionId)
-	if !ok {
+	// ClientHelloInner, obtained by decoding EncodedClientHelloInner.
+	rawHelloInner := echDecodeClientHelloInner(rawEncodedHelloInner, hello.marshal(), hello.sessionId)
+	if rawHelloInner == nil {
 		c.sendAlert(alertIllegalParameter)
-		return nil, fmt.Errorf("ech: %s", err)
+		return nil, fmt.Errorf("ech: failed to decode EncodedClientHelloInner")
 	}
-
 	helloInner := new(clientHelloMsg)
 	if !helloInner.unmarshal(rawHelloInner) {
 		c.sendAlert(alertIllegalParameter)
-		return nil, fmt.Errorf("ech: %s", err)
-	}
-
-	// Update the HRR pre-shared-key. This is used to decrypt the second
-	// ClientHelloInner in case an HRR is sent.
-	c.ech.hrrPsk = ctx.hrrPsk()
-
-	if c.hrrTriggered && !c.ech.accepted {
-		// ECH was not accepted prior to HRR then accepted after. Because the
-		// configuration identifier is the same in the first ClientHello as it
-		// is in the second, this indicates a server failure, likely due to the
-		// ECH key being rotated.
-		c.sendAlert(alertInternalError)
-		return nil, errors.New("ech: hrr: accept after reject")
+		return nil, fmt.Errorf("ech: failed to parse ClientHelloInner")
 	}
 
 	// Accept ECH.
 	c.ech.offered = true
 	c.ech.accepted = true
 	return helloInner, nil
-}
-
-// echCipherSuite represents an ECH ciphersuite, a KDF/AEAD algorithm pair. This
-// is different from an HPKE ciphersuite, which represents a KEM, KDF, and an
-// AEAD algorithm.
-type echCipherSuite struct {
-	kdfId, aeadId uint16
-}
-
-// echUnmarshalHpkePublicKey parses a serialized public key for the KEM algorithm
-// identified by `kemId`.
-func echUnmarshalHpkePublicKey(raw []byte, kemId uint16) (hpke.KEMPublicKey, error) {
-	// NOTE: Stand-in values for KDF/AEAD algorithms are ignored.
-	hpkeSuite, err := hpkeAssembleCipherSuite(kemId, dummyKdfId, dummyAeadId)
-	if err != nil {
-		return nil, err
-	}
-	return hpkeSuite.KEM.Deserialize(raw)
-}
-
-// echUnmarshalHpkeSecretKey parses a serialized secret key for the KEM algorithm
-// identified by `kemId`.
-func echUnmarshalHpkeSecretKey(raw []byte, kemId uint16) (hpke.KEMPrivateKey, error) {
-	// NOTE: Stand-in values for KDF/AEAD algorithms are ignored.
-	hpkeSuite, err := hpkeAssembleCipherSuite(kemId, dummyKdfId, dummyAeadId)
-	if err != nil {
-		return nil, err
-	}
-	return hpkeSuite.KEM.DeserializePrivate(raw)
-}
-
-// echCreateHpkeKdf returns an HPKE KDF scheme.
-func echCreateHpkeKdf(kdfId uint16) (hpke.KDFScheme, error) {
-	// NOTE: Stand-in values for KEM/AEAD algorithms are ignored.
-	hpkeSuite, err := hpkeAssembleCipherSuite(dummyKemId, kdfId, dummyAeadId)
-	if err != nil {
-		return nil, err
-	}
-	return hpkeSuite.KDF, nil
-}
-
-func echIsCipherSuiteSupported(suite echCipherSuite) bool {
-	// NOTE: Stand-in values for KEM algorithm is ignored.
-	_, err := hpkeAssembleCipherSuite(dummyKemId, suite.kdfId, suite.aeadId)
-	return err == nil
-}
-
-func echIsKemSupported(kemId uint16) bool {
-	// NOTE: Stand-in values for KDF/AEAD algorithms are ignored.
-	_, err := hpkeAssembleCipherSuite(kemId, dummyKdfId, dummyAeadId)
-	return err == nil
-}
-
-// echContent represents an HPKE context (irtf-cfrg-hpke-05).
-type echContext struct {
-	enc       *hpke.EncryptContext
-	dec       *hpke.DecryptContext
-	isClient  bool
-	hpkeSuite hpke.CipherSuite
-}
-
-// cipherSuite returns the ECH ciphersuite for this HPKE context.
-func (ctx *echContext) cipherSuite() echCipherSuite {
-	return echCipherSuite{
-		kdfId:  uint16(ctx.hpkeSuite.KDF.ID()),
-		aeadId: uint16(ctx.hpkeSuite.AEAD.ID()),
-	}
-}
-
-// echUnmarshalServerContext parses the server's HPKE context.
-func echUnmarshalServerContext(raw []byte) (*echContext, error) {
-	decryptechContext, err := hpke.UnmarshalDecryptContext(raw)
-	if err != nil {
-		return nil, err
-	}
-
-	hpkeSuite, err := hpkeAssembleCipherSuite(uint16(decryptechContext.KEMID), uint16(decryptechContext.KDFID), uint16(decryptechContext.AEADID))
-	if err != nil {
-		return nil, err
-	}
-
-	return &echContext{
-		enc:       nil,
-		dec:       decryptechContext,
-		isClient:  false,
-		hpkeSuite: hpkeSuite,
-	}, nil
-}
-
-// marshalServer returns the server's serialized HPKE context.
-func (ctx *echContext) marshalServer() ([]byte, error) {
-	return ctx.dec.Marshal()
-}
-
-// encrypt seals the ClientHelloInner in the client's HPKE context.
-func (ctx *echContext) seal(aad, inner []byte) (payload []byte) {
-	if !ctx.isClient {
-		panic("seal() is not defined for server")
-	}
-	return ctx.enc.Seal(aad, inner)
-}
-
-// decrypt opens the encrypted ClientHelloInner in the server's HPKE context.
-func (ctx *echContext) open(aad, payload []byte) (inner []byte, err error) {
-	if ctx.isClient {
-		panic("open() is not defined for client")
-	}
-	return ctx.dec.Open(aad, payload)
-}
-
-// hrrPsk returns the PSK used to bind the first ClientHelloOuter to the second
-// in case the backend server sends a HelloRetryRequest.
-func (ctx *echContext) hrrPsk() []byte {
-	if ctx.isClient {
-		return ctx.enc.Export([]byte(echHpkeHrrKeyExporter), echHpkeHrrKeyLen)
-	}
-	return ctx.dec.Export([]byte(echHpkeHrrKeyExporter), echHpkeHrrKeyLen)
-}
-
-// configId computes the configuration identifier for a serialized ECHConfig.
-func (ctx *echContext) configId(config []byte) []byte {
-	kdf := ctx.hpkeSuite.KDF
-	return kdf.Expand(kdf.Extract(nil, config), []byte(echHpkeInfoConfigId), kdf.OutputSize())
 }
 
 // echClient represents a ClientECH structure, the payload of the client's
@@ -643,15 +486,60 @@ func echReadContextHandle(s *cryptobyte.String, handle *echContextHandle) bool {
 	return true
 }
 
-// echEncodeClientHelloInner interprets data as a ClientHelloInner message and
-// transforms into an EncodedClinetHelloInner. It also returns a bool indicating
-// if parsing the ClientHelloInner succeeded.
+// echCipherSuite represents an ECH ciphersuite, a KDF/AEAD algorithm pair. This
+// is different from an HPKE ciphersuite, which represents a KEM/KDF/AEAD
+// triple.
+type echCipherSuite struct {
+	kdfId, aeadId uint16
+}
+
+// Generates a grease ECH extension using a hard-coded KEM public key.
+func echGenerateDummyExt(rand io.Reader) ([]byte, error) {
+	var err error
+	var dummyX25519PublicKey = []byte{
+		143, 38, 37, 36, 12, 6, 229, 30, 140, 27, 167, 73, 26, 100, 203, 107, 216,
+		81, 163, 222, 52, 211, 54, 210, 46, 37, 78, 216, 157, 97, 241, 244,
+	}
+	dummyEncodedHelloInnerLen := 100 // TODO(cjpatton): Compute this correctly.
+	kem, kdf, aead := defaultHPKESuite.Params()
+
+	pk, err := kem.Scheme().UnmarshalBinaryPublicKey(dummyX25519PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("tls: grease ech: failed to parse dummy public key: %s", err)
+	}
+	sender, err := defaultHPKESuite.NewSender(pk, nil)
+	if err != nil {
+		return nil, fmt.Errorf("tls: grease ech: failed to create sender: %s", err)
+	}
+
+	var ech echClient
+	ech.handle.suite.kdfId = uint16(kdf)
+	ech.handle.suite.aeadId = uint16(aead)
+	ech.handle.configId = make([]byte, 8)
+	_, err = io.ReadFull(rand, ech.handle.configId)
+	if err != nil {
+		return nil, fmt.Errorf("tls: grease ech:: %s", err)
+	}
+	ech.handle.enc, _, err = sender.Setup(rand)
+	if err != nil {
+		return nil, fmt.Errorf("tls: grease ech:: %s", err)
+	}
+	ech.payload = make([]byte, dummyEncodedHelloInnerLen+defaultHPKESuiteTagLen)
+	if _, err = io.ReadFull(rand, ech.payload); err != nil {
+		return nil, fmt.Errorf("tls: grease ech:: %s", err)
+	}
+	return ech.marshal(), nil
+}
+
+// echEncodeClientHelloInner interprets innerData as a ClientHelloInner message
+// and transforms it into an EncodedClientHelloInner. Returns nil if parsing
+// innerData fails.
 //
 // outerExtensions specifies the contiguous sequence of extensions that will be
-// incorporated.
-func echEncodeClientHelloInner(data []byte, outerExtensions []uint16) ([]byte, bool) {
+// incorporated using the "ech_outer_extensions" mechanism.
+func echEncodeClientHelloInner(innerData []byte, outerExtensions []uint16) []byte {
 	var (
-		errReadFailure           = errors.New("read failure")
+		errIllegalParameter      = errors.New("illegal parameter")
 		msgType                  uint8
 		legacyVersion            uint16
 		random                   []byte
@@ -663,10 +551,10 @@ func echEncodeClientHelloInner(data []byte, outerExtensions []uint16) ([]byte, b
 		b                        cryptobyte.Builder
 	)
 
-	u := cryptobyte.String(data)
+	u := cryptobyte.String(innerData)
 	if !u.ReadUint8(&msgType) ||
 		!u.ReadUint24LengthPrefixed(&s) || !u.Empty() {
-		return nil, false
+		return nil
 	}
 
 	if !s.ReadUint16(&legacyVersion) ||
@@ -674,16 +562,16 @@ func echEncodeClientHelloInner(data []byte, outerExtensions []uint16) ([]byte, b
 		!s.ReadUint8LengthPrefixed(&legacySessionId) ||
 		!s.ReadUint16LengthPrefixed(&cipherSuites) ||
 		!s.ReadUint8LengthPrefixed(&legacyCompressionMethods) {
-		return nil, false
+		return nil
 	}
 
 	if s.Empty() {
 		// Extensions field must be present in TLS 1.3.
-		return nil, false
+		return nil
 	}
 
 	if !s.ReadUint16LengthPrefixed(&extensions) || !s.Empty() {
-		return nil, false
+		return nil
 	}
 
 	b.AddUint16(legacyVersion)
@@ -707,7 +595,7 @@ func echEncodeClientHelloInner(data []byte, outerExtensions []uint16) ([]byte, b
 			var extData cryptobyte.String
 			if !extensions.ReadUint16(&ext) ||
 				!extensions.ReadUint16LengthPrefixed(&extData) {
-				panic(cryptobyte.BuildError{Err: errReadFailure})
+				panic(cryptobyte.BuildError{Err: errIllegalParameter})
 			}
 
 			if len(outerExtensions) > 0 && ext == outerExtensions[0] {
@@ -720,7 +608,7 @@ func echEncodeClientHelloInner(data []byte, outerExtensions []uint16) ([]byte, b
 				for _, outerExt := range outerExtensions[1:] {
 					if !extensions.ReadUint16(&ext) ||
 						!extensions.ReadUint16LengthPrefixed(&extData) {
-						panic(cryptobyte.BuildError{Err: errReadFailure})
+						panic(cryptobyte.BuildError{Err: errIllegalParameter})
 					}
 					if ext != outerExt {
 						panic("internal error: malformed ClientHelloInner")
@@ -737,13 +625,13 @@ func echEncodeClientHelloInner(data []byte, outerExtensions []uint16) ([]byte, b
 	})
 
 	encodedData, err := b.Bytes()
-	if err == errReadFailure {
-		return nil, false // Reading failed
+	if err == errIllegalParameter {
+		return nil // Input malformed
 	} else if err != nil {
-		panic(err) // Writing failed
+		panic(err) // Host encountered internal error
 	}
 
-	return encodedData, true
+	return encodedData
 }
 
 func echAddOuterExtensions(b *cryptobyte.Builder, outerExtensions []uint16) {
@@ -753,18 +641,21 @@ func echAddOuterExtensions(b *cryptobyte.Builder, outerExtensions []uint16) {
 			for _, outerExt := range outerExtensions {
 				b.AddUint16(outerExt)
 			}
+			if testingECHOuterExtIllegal {
+				// This is not allowed.
+				b.AddUint16(extensionECH)
+			}
 		})
 	})
 }
 
-// echDecodeClientHelloInner interprets data as an EncodedClientHelloInner
+// echDecodeClientHelloInner interprets encodedData as an EncodedClientHelloInner
 // message and substitutes the "outer_extension" extension with extensions from
-// outerData, interpreted as the ClientHelloOuter message. Returns the decoded
-// ClientHelloInner and a bool indicating whether parsing
-// EncodedClientHelloInner succeeded.
-func echDecodeClientHelloInner(data []byte, outerData, outerSessionId []byte) ([]byte, bool) {
+// outerData, interpreted as the ClientHelloOuter message. Returns nil if
+// parsing encodedData fails.
+func echDecodeClientHelloInner(encodedData, outerData, outerSessionId []byte) []byte {
 	var (
-		errReadFailure           = errors.New("read failure")
+		errIllegalParameter      = errors.New("illegal parameter")
 		legacyVersion            uint16
 		random                   []byte
 		legacySessionId          cryptobyte.String
@@ -774,26 +665,26 @@ func echDecodeClientHelloInner(data []byte, outerData, outerSessionId []byte) ([
 		b                        cryptobyte.Builder
 	)
 
-	s := cryptobyte.String(data)
+	s := cryptobyte.String(encodedData)
 	if !s.ReadUint16(&legacyVersion) ||
 		!s.ReadBytes(&random, 32) ||
 		!s.ReadUint8LengthPrefixed(&legacySessionId) ||
 		!s.ReadUint16LengthPrefixed(&cipherSuites) ||
 		!s.ReadUint8LengthPrefixed(&legacyCompressionMethods) {
-		return nil, false
+		return nil
 	}
 
 	if len(legacySessionId) > 0 {
-		return nil, false
+		return nil
 	}
 
 	if s.Empty() {
 		// Extensions field must be present in TLS 1.3.
-		return nil, false
+		return nil
 	}
 
 	if !s.ReadUint16LengthPrefixed(&extensions) || !s.Empty() {
-		return nil, false
+		return nil
 	}
 
 	b.AddUint8(typeClientHello)
@@ -816,14 +707,14 @@ func echDecodeClientHelloInner(data []byte, outerData, outerSessionId []byte) ([
 				var extData cryptobyte.String
 				if !extensions.ReadUint16(&ext) ||
 					!extensions.ReadUint16LengthPrefixed(&extData) {
-					panic(cryptobyte.BuildError{Err: errReadFailure})
+					panic(cryptobyte.BuildError{Err: errIllegalParameter})
 				}
 
 				if ext == extensionECHOuterExtensions {
 					if handledOuterExtensions {
 						// It is an error to send any extension more than once in a
 						// single message.
-						panic(cryptobyte.BuildError{Err: errReadFailure})
+						panic(cryptobyte.BuildError{Err: errIllegalParameter})
 					}
 					handledOuterExtensions = true
 
@@ -833,12 +724,12 @@ func echDecodeClientHelloInner(data []byte, outerData, outerSessionId []byte) ([
 					if !extData.ReadUint8LengthPrefixed(&outerExtData) ||
 						len(outerExtData)%2 != 0 ||
 						!extData.Empty() {
-						panic(cryptobyte.BuildError{Err: errReadFailure})
+						panic(cryptobyte.BuildError{Err: errIllegalParameter})
 					}
 					for !outerExtData.Empty() {
 						if !outerExtData.ReadUint16(&ext) ||
-							!echIsValidOuterExtension(ext) {
-							panic(cryptobyte.BuildError{Err: errReadFailure})
+							ext == extensionECH {
+							panic(cryptobyte.BuildError{Err: errIllegalParameter})
 						}
 						// Mark outer extension as not yet incorporated.
 						outer[ext] = false
@@ -857,13 +748,13 @@ func echDecodeClientHelloInner(data []byte, outerData, outerSessionId []byte) ([
 						}
 						return true
 					}) {
-						panic(cryptobyte.BuildError{Err: errReadFailure})
+						panic(cryptobyte.BuildError{Err: errIllegalParameter})
 					}
 
 					// Ensure that all outer extensions have been incorporated.
 					for _, incorporated := range outer {
 						if !incorporated {
-							panic(cryptobyte.BuildError{Err: errReadFailure})
+							panic(cryptobyte.BuildError{Err: errIllegalParameter})
 						}
 					}
 				} else {
@@ -876,34 +767,22 @@ func echDecodeClientHelloInner(data []byte, outerData, outerSessionId []byte) ([
 		})
 	})
 
-	decodedData, err := b.Bytes()
-	if err == errReadFailure {
-		return nil, false // Reading failed
+	innerData, err := b.Bytes()
+	if err == errIllegalParameter {
+		return nil // Input malformed
 	} else if err != nil {
-		panic(err) // Writing failed
+		panic(err) // Host encountered internal error
 	}
 
-	return decodedData, true
+	return innerData
 }
 
-// Returns true if the code point is a valid outer extension.
-func echIsValidOuterExtension(ext uint16) bool {
-	// The client MUST NOT attempt to compress the ECH extension.
-	return !echIsValidVersion(ext)
-}
-
-// Returns true if the code point is for a version of ECH that this package
-// implements.
-func echIsValidVersion(ext uint16) bool {
-	return ext == extensionECH
-}
-
-// encodeClientHelloOuterAAD interprets data as ClientHelloOuter and maps it to
-// ClientHelloOuterAAD. Returns a bool indicated whether parsing
-// ClientHelloOuter succeeded.
-func encodeClientHelloOuterAAD(data []byte, ext uint16) ([]byte, bool) {
+// echEncodeClientHelloOuterAAD interprets outerData as ClientHelloOuter and
+// handleData as an ECH context handle and maps these to a ClientHelloOuterAAD.
+// Returns nil if parsing outerData fails.
+func echEncodeClientHelloOuterAAD(outerData, handleData []byte) []byte {
 	var (
-		errReadFailure           = errors.New("read failure")
+		errIllegalParameter      = errors.New("illegal parameter")
 		msgType                  uint8
 		legacyVersion            uint16
 		random                   []byte
@@ -915,10 +794,10 @@ func encodeClientHelloOuterAAD(data []byte, ext uint16) ([]byte, bool) {
 		b                        cryptobyte.Builder
 	)
 
-	u := cryptobyte.String(data)
+	u := cryptobyte.String(outerData)
 	if !u.ReadUint8(&msgType) ||
 		!u.ReadUint24LengthPrefixed(&s) || !u.Empty() {
-		return nil, false
+		return nil
 	}
 
 	if !s.ReadUint16(&legacyVersion) ||
@@ -926,19 +805,19 @@ func encodeClientHelloOuterAAD(data []byte, ext uint16) ([]byte, bool) {
 		!s.ReadUint8LengthPrefixed(&legacySessionId) ||
 		!s.ReadUint16LengthPrefixed(&cipherSuites) ||
 		!s.ReadUint8LengthPrefixed(&legacyCompressionMethods) {
-		return nil, false
+		return nil
 	}
 
 	if s.Empty() {
 		// Extensions field must be present in TLS 1.3.
-		return nil, false
+		return nil
 	}
 
 	if !s.ReadUint16LengthPrefixed(&extensions) || !s.Empty() {
-		return nil, false
+		return nil
 	}
 
-	b.AddUint8(msgType)
+	b.AddBytes(handleData)
 	b.AddUint24LengthPrefixed(func(b *cryptobyte.Builder) {
 		b.AddUint16(legacyVersion)
 		b.AddBytes(random)
@@ -957,7 +836,7 @@ func encodeClientHelloOuterAAD(data []byte, ext uint16) ([]byte, bool) {
 				var extData cryptobyte.String
 				if !extensions.ReadUint16(&ext) ||
 					!extensions.ReadUint16LengthPrefixed(&extData) {
-					panic(cryptobyte.BuildError{Err: errReadFailure})
+					panic(cryptobyte.BuildError{Err: errIllegalParameter})
 				}
 
 				// Copy all extensions except for ECH.
@@ -971,22 +850,22 @@ func encodeClientHelloOuterAAD(data []byte, ext uint16) ([]byte, bool) {
 		})
 	})
 
-	encodedData, err := b.Bytes()
-	if err == errReadFailure {
-		return nil, false // Reading failed
+	outerAadData, err := b.Bytes()
+	if err == errIllegalParameter {
+		return nil // Input malformed
 	} else if err != nil {
-		panic(err) // Writing failed
+		panic(err) // Host encountered internal error
 	}
 
-	return encodedData, true
+	return outerAadData
 }
 
 // processClientHelloExtensions interprets data as a ClientHello and applies a
 // function proc to each extension. Returns a bool indicating whether parsing
 // succeeded.
 func processClientHelloExtensions(data []byte, proc func(ext uint16, extData cryptobyte.String) bool) bool {
-	_, extensionsData, ok := splitClientHelloExtensions(data)
-	if !ok {
+	_, extensionsData := splitClientHelloExtensions(data)
+	if extensionsData == nil {
 		return false
 	}
 
@@ -1018,8 +897,8 @@ func processClientHelloExtensions(data []byte, proc func(ext uint16, extData cry
 // splitClientHelloExtensions interprets data as a ClientHello message and
 // returns two strings: the first contains the start of the ClientHello up to
 // the start of the extensions; and the second is the length-prefixed
-// extensions. It also returns a bool indicating whether parsing succeeded.
-func splitClientHelloExtensions(data []byte) ([]byte, []byte, bool) {
+// extensions. Returns (nil, nil) if parsing of data fails.
+func splitClientHelloExtensions(data []byte) ([]byte, []byte) {
 	s := cryptobyte.String(data)
 
 	var ignored uint16
@@ -1027,26 +906,24 @@ func splitClientHelloExtensions(data []byte) ([]byte, []byte, bool) {
 	if !s.Skip(4) || // message type and uint24 length field
 		!s.ReadUint16(&ignored) || !s.Skip(32) || // vers, random
 		!s.ReadUint8LengthPrefixed(&t) { // session_id
-		return nil, nil, false
+		return nil, nil
 	}
 
 	if !s.ReadUint16LengthPrefixed(&t) { // cipher_suites
-		return nil, nil, false
+		return nil, nil
 	}
 
 	if !s.ReadUint8LengthPrefixed(&t) { // compression_methods
-		return nil, nil, false
+		return nil, nil
 	}
 
-	return data[:len(data)-len(s)], s, true
+	return data[:len(data)-len(s)], s
 }
 
 func (c *Config) echSelectConfig() *ECHConfig {
 	for _, echConfig := range c.ClientECHConfigs {
-		// A suitable configuration is one that offers an HPKE ciphersuite that
-		// is supported by the client and indicates the version of ECH
-		// implemented by this TLS client.
-		if echConfig.isSupported() && echIsValidVersion(echConfig.version) {
+		if _, err := echConfig.selectSuite(); err == nil &&
+			echConfig.version == extensionECH {
 			return &echConfig
 		}
 	}
@@ -1057,12 +934,16 @@ func (c *Config) echCanOffer() bool {
 	if c == nil {
 		return false
 	}
-	return c.ECHEnabled && c.echSelectConfig() != nil && c.maxSupportedVersion() >= VersionTLS13
+	return c.ECHEnabled &&
+		c.echSelectConfig() != nil &&
+		c.maxSupportedVersion() >= VersionTLS13
 }
 
 func (c *Config) echCanAccept() bool {
 	if c == nil {
 		return false
 	}
-	return c.ECHEnabled && c.ServerECHProvider != nil && c.maxSupportedVersion() >= VersionTLS13
+	return c.ECHEnabled &&
+		c.ServerECHProvider != nil &&
+		c.maxSupportedVersion() >= VersionTLS13
 }

--- a/src/crypto/tls/ech_provider.go
+++ b/src/crypto/tls/ech_provider.go
@@ -1,21 +1,33 @@
+// Copyright 2020 Cloudflare, Inc. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
 package tls
+
+import (
+	"circl/hpke"
+	"circl/kem"
+	"errors"
+	"fmt"
+
+	"golang.org/x/crypto/cryptobyte"
+)
+
+const (
+	maxConfigIdLen = 255
+)
 
 // ECHProvider specifies the interface of an ECH service provider that decrypts
 // the ECH payload on behalf of the client-facing server. It also defines the
 // set of acceptable ECH configurations.
 type ECHProvider interface {
-	// GetContext attempts to construct the HPKE context used by the
-	// client-facing server for decryption. (See draft-irtf-cfrg-hpke-05,
+	// GetDecryptionContext attempts to construct the HPKE context used by the
+	// client-facing server for decryption. (See draft-irtf-cfrg-hpke-07,
 	// Section 5.2.)
 	//
 	// handle encodes the parameters of the client's "encrypted_client_hello"
 	// extension that are needed to construct the context. In
-	// draft-ietf-tls-esni-08, these are the ECH cipher suite, the identity of
+	// draft-ietf-tls-esni-09, these are the ECH cipher suite, the identity of
 	// the ECH configuration, and the encapsulated key.
-	//
-	// hrrPsk is the PSK used to construct the context. This is set by the
-	// caller in case the server previously sent a HelloRetryRequest in this
-	// connection. Otherwise, len(hrrPsk) == 0.
 	//
 	// version is the version of ECH indicated by the client.
 	//
@@ -25,9 +37,11 @@ type ECHProvider interface {
 	// res.Status == ECHProviderStatusReject indicates the caller must reject
 	// ECH. res.RetryConfigs may be set.
 	//
-	// res.Status == ECHProviderStatusAbort indicates the caller must abort the
-	// handshake. res.Alert and res.Error are set.
-	GetContext(handle, hrrPsk []byte, version uint16) (res ECHProviderResult)
+	// res.Status == ECHProviderStatusAbort indicates the caller should abort
+	// the handshake.  Note that, in some cases, it's appropriate to reject
+	// rather than abort. In particular, aborting with "illegal_parameter" might
+	// "stick out". res.Alert and res.Error are set.
+	GetDecryptionContext(handle []byte, version uint16) (res ECHProviderResult)
 }
 
 // ECHProviderStatus is the status of the ECH provider's response.
@@ -57,22 +71,242 @@ type ECHProviderResult struct {
 	// by the provider and no error was reported. The data has the following
 	// format (in TLS syntax):
 	//
-	// enum { sender(0), receiver(1) } HpkeRole;
+	// enum { sealer(0), opener(1) } HpkeRole;
 	//
 	// struct {
 	//     HpkeRole role;
-	//     HpkeKemId kem_id;   // as defined in draft-irtf-cfrg-hpke-05
-	//     HpkeKdfId kdf_id;   // as defined in draft-irtf-cfrg-hpke-05
-	//     HpkeAeadId aead_id; // as defined in draft-irtf-cfrg-hpke-05
+	//     HpkeKemId kem_id;   // as defined in draft-irtf-cfrg-hpke-07
+	//     HpkeKdfId kdf_id;   // as defined in draft-irtf-cfrg-hpke-07
+	//     HpkeAeadId aead_id; // as defined in draft-irtf-cfrg-hpke-07
 	//     opaque exporter_secret<0..255>;
 	//     opaque key<0..255>;
-	//     opaque nonce<0..255>;
-	//     uint64 seq;
+	//     opaque base_nonce<0..255>;
+	//     opaque seq<0..255>;
 	// } HpkeContext;
-	//
-	// NOTE(cjpatton): This format is specified neither in the ECH spec nor the
-	// HPKE spec. It is the format chosen for the HPKE implementation that we're
-	// using. See
-	// https://github.com/cisco/go-hpke/blob/9e7d3e90b7c3a5b08f3099c49520c587568c77d6/hpke.go#L198
 	Context []byte
+}
+
+// EXP_ECHKeySet implements the ECHProvider interface for a sequence of ECH keys.
+//
+// NOTE: This API is EXPERIMENTAL and subject to change.
+type EXP_ECHKeySet struct {
+	// The serialized ECHConfigs, in order of the server's preference.
+	configs []byte
+
+	// Maps a configuration identifier to its secret key.
+	sk map[[maxConfigIdLen + 1]byte]EXP_ECHKey
+}
+
+// EXP_NewECHKeySet constructs an EXP_ECHKeySet.
+func EXP_NewECHKeySet(keys []EXP_ECHKey) (*EXP_ECHKeySet, error) {
+	keySet := new(EXP_ECHKeySet)
+	keySet.sk = make(map[[maxConfigIdLen + 1]byte]EXP_ECHKey)
+	configs := make([]byte, 0)
+	for _, key := range keys {
+		// Compute the set of KDF algorithms supported by this configuration.
+		kdfIds := make(map[uint16]bool)
+		for _, suite := range key.config.suites {
+			kdfIds[suite.kdfId] = true
+		}
+
+		// Compute the configuration identifier for each KDF.
+		for kdfId, _ := range kdfIds {
+			configId, err := key.config.id(hpke.KDF(kdfId))
+			if err != nil {
+				return nil, err
+			}
+
+			var b cryptobyte.Builder
+			b.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
+				b.AddBytes(configId)
+			})
+			var id [maxConfigIdLen + 1]byte // Initialized to zero
+			copy(id[:], b.BytesOrPanic())
+			keySet.sk[id] = key
+		}
+
+		configs = append(configs, key.config.raw...)
+	}
+
+	var b cryptobyte.Builder
+	b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
+		b.AddBytes(configs)
+	})
+	keySet.configs = b.BytesOrPanic()
+
+	return keySet, nil
+}
+
+// GetDecryptionContext is required by the ECHProvider interface.
+func (keySet *EXP_ECHKeySet) GetDecryptionContext(rawHandle []byte, version uint16) (res ECHProviderResult) {
+	// Propagate retry configurations regardless of the result. The caller sends
+	// these to the clients only if it rejects.
+	res.RetryConfigs = keySet.configs
+
+	// Ensure we know how to proceed, i.e., the caller has indicated a supported
+	// version of ECH. Currently only draft-ietf-tls-esni-09 is supported.
+	if version != extensionECH {
+		res.Status = ECHProviderAbort
+		res.Alert = uint8(alertInternalError)
+		res.Error = errors.New("version not supported")
+		return // Abort
+	}
+
+	// Parse the handle.
+	s := cryptobyte.String(rawHandle)
+	handle := new(echContextHandle)
+	if !echReadContextHandle(&s, handle) || !s.Empty() {
+		// This is the result of a client-side error. However, aborting with
+		// "illegal_parameter" would stick out, so we reject instead.
+		res.Status = ECHProviderReject
+		res.RetryConfigs = keySet.configs
+		return // Reject
+	}
+	handle.raw = rawHandle
+
+	// Look up the secret key for the configuration indicated by the client.
+	var id [maxConfigIdLen + 1]byte // Initialized to zero
+	var b cryptobyte.Builder
+	b.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
+		b.AddBytes(handle.configId)
+	})
+	copy(id[:], b.BytesOrPanic())
+	key, ok := keySet.sk[id]
+	if !ok {
+		res.Status = ECHProviderReject
+		res.RetryConfigs = keySet.configs
+		return // Reject
+	}
+
+	// Ensure that support for the selected ciphersuite is indicated by the
+	// configuration.
+	suite := handle.suite
+	if !key.config.isPeerCipherSuiteSupported(suite) {
+		// This is the result of a client-side error. However, aborting with
+		// "illegal_parameter" would stick out, so we reject instead.
+		res.Status = ECHProviderReject
+		res.RetryConfigs = keySet.configs
+		return // Reject
+	}
+
+	// Ensure the version indicated by the client matches the version supported
+	// by the configuration.
+	if version != key.config.version {
+		// This is the result of a client-side error. However, aborting with
+		// "illegal_parameter" would stick out, so we reject instead.
+		res.Status = ECHProviderReject
+		res.RetryConfigs = keySet.configs
+		return // Reject
+	}
+
+	// Compute the decryption context.
+	opener, err := key.setupOpener(handle.enc, suite)
+	if err != nil {
+		res.Status = ECHProviderAbort
+		res.Alert = uint8(alertInternalError)
+		res.Error = err
+		return // Abort
+	}
+
+	// Serialize the decryption context.
+	res.Context, err = opener.MarshalBinary()
+	if err != nil {
+		res.Status = ECHProviderAbort
+		res.Alert = uint8(alertInternalError)
+		res.Error = err
+		return // Abort
+	}
+
+	res.Status = ECHProviderSuccess
+	return // Success
+}
+
+// EXP_ECHKey represents an ECH key and its corresponding configuration. The
+// encoding of an ECH Key has the format defined below (in TLS syntax). Note
+// that the ECH standard does not specify this format.
+//
+// struct {
+//     opaque sk<0..2^16-1>;
+//     ECHConfig config<0..2^16>; // draft-ietf-tls-esni-09
+// } ECHKey;
+type EXP_ECHKey struct {
+	sk     kem.PrivateKey
+	config ECHConfig
+}
+
+// EXP_UnmarshalECHKeys parses a sequence of ECH keys.
+func EXP_UnmarshalECHKeys(raw []byte) ([]EXP_ECHKey, error) {
+	var (
+		err                  error
+		key                  EXP_ECHKey
+		sk, config, contents cryptobyte.String
+	)
+	s := cryptobyte.String(raw)
+	keys := make([]EXP_ECHKey, 0)
+KeysLoop:
+	for !s.Empty() {
+		if !s.ReadUint16LengthPrefixed(&sk) ||
+			!s.ReadUint16LengthPrefixed(&config) {
+			return nil, errors.New("error parsing key")
+		}
+
+		key.config.raw = config
+		if !config.ReadUint16(&key.config.version) ||
+			!config.ReadUint16LengthPrefixed(&contents) ||
+			!config.Empty() {
+			return nil, errors.New("error parsing config")
+		}
+
+		if key.config.version != extensionECH {
+			continue KeysLoop
+		}
+		if !readConfigContents(&contents, &key.config) {
+			return nil, errors.New("error parsing config contents")
+		}
+
+		for _, suite := range key.config.suites {
+			if !hpke.KDF(suite.kdfId).IsValid() ||
+				!hpke.AEAD(suite.aeadId).IsValid() {
+				continue KeysLoop
+			}
+		}
+
+		kem := hpke.KEM(key.config.kemId)
+		if !kem.IsValid() {
+			continue KeysLoop
+		}
+		key.config.pk, err = kem.Scheme().UnmarshalBinaryPublicKey(key.config.rawPublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing public key: %s", err)
+		}
+		key.sk, err = kem.Scheme().UnmarshalBinaryPrivateKey(sk)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing secret key: %s", err)
+		}
+
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+// setupOpener computes the HPKE context used by the server in the ECH
+// extension.i
+func (key *EXP_ECHKey) setupOpener(enc []byte, suite echCipherSuite) (hpke.Opener, error) {
+	if key.config.raw == nil {
+		panic("raw config not set")
+	}
+	hpkeSuite, err := hpkeAssembleSuite(
+		key.config.kemId,
+		suite.kdfId,
+		suite.aeadId,
+	)
+	if err != nil {
+		return nil, err
+	}
+	info := append(append([]byte(echHpkeInfoSetup), 0), key.config.raw...)
+	receiver, err := hpkeSuite.NewReceiver(key.sk, info)
+	if err != nil {
+		return nil, err
+	}
+	return receiver.Setup(enc)
 }

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -123,27 +123,6 @@ func (hs *clientHandshakeStateTLS13) handshake() error {
 		}
 	}
 
-	// Determine if ECH was accepted.
-	if hs.c.ech.offered {
-		secret := hs.suite.extract(hs.helloInner.random, nil)
-		context := hs.serverHello.random[:24]
-		acceptConfirmation := hs.suite.expandLabel(secret, echTls13LabelAcceptConfirm, context, 8)
-		if bytes.Equal(hs.serverHello.random[24:], acceptConfirmation) {
-			c.ech.accepted = true
-			hs.hello = hs.helloInner
-			hs.transcript = hs.transcriptInner
-		}
-	}
-
-	// Resolve the server name now that ECH acceptance has been determined.
-	//
-	// NOTE(cjpatton): Currently the client sends the same ALPN extension in the
-	// ClientHelloInner and ClientHelloOuter. If that changes, then we'll need
-	// to resolve ALPN here as well.
-	c.serverName = hs.hello.serverName
-
-	hs.transcript.Write(hs.serverHello.marshal())
-
 	c.buffering = true
 	if err := hs.processServerHello(); err != nil {
 		return err
@@ -353,9 +332,17 @@ func (hs *clientHandshakeStateTLS13) processHelloRetryRequest() error {
 	}
 
 	if testingECHIllegalHandleAfterHRR {
-		// Triggers a server abort, since this changes the cipher suite offered
-		// by the client.
-		hs.hello.encryptedClientHello[0] ^= 0xff
+		// Triggers a server abort, since the "config_id" and "enc" fields are
+		// expected to be empty after HRR.
+		ech, err := echUnmarshalClient(hs.hello.ech)
+		if err != nil {
+			return err
+		}
+		ech.raw = nil
+		ech.handle.raw = nil
+		ech.handle.configId = []byte{1, 2, 3, 4}
+		ech.handle.enc = []byte{1, 2, 3, 4}
+		hs.hello.ech = ech.marshal()
 	}
 
 	if _, err := c.writeRecord(recordTypeHandshake, hs.hello.marshal()); err != nil {
@@ -462,6 +449,37 @@ func (hs *clientHandshakeStateTLS13) establishHandshakeKeys() error {
 	handshakeSecret := hs.suite.extract(sharedKey,
 		hs.suite.deriveSecret(earlySecret, "derived", nil))
 
+	// If ECH was offered, then determine if it was accepted.
+	if c.ech.offered {
+		confTranscript := cloneHash(hs.transcriptInner, hs.suite.hash)
+		if confTranscript == nil {
+			c.sendAlert(alertInternalError)
+			return errors.New("tls: internal error: failed to clone hash")
+		}
+		var random [32]byte // initialized to zero
+		copy(random[:24], hs.serverHello.random[:24])
+		serverHelloConf := *hs.serverHello
+		serverHelloConf.raw = nil
+		serverHelloConf.random = random[:]
+		confTranscript.Write(serverHelloConf.marshal())
+		conf := hs.suite.deriveSecret(handshakeSecret,
+			echAcceptConfirmationLabel, confTranscript)
+		if bytes.Equal(hs.serverHello.random[24:], conf[:8]) {
+			c.ech.accepted = true
+			hs.hello = hs.helloInner
+			hs.transcript = hs.transcriptInner
+		}
+	}
+
+	hs.transcript.Write(hs.serverHello.marshal())
+
+	// Resolve the server name now that ECH acceptance has been determined.
+	//
+	// NOTE(cjpatton): Currently the client sends the same ALPN extension in the
+	// ClientHelloInner and ClientHelloOuter. If that changes, then we'll need
+	// to resolve ALPN here as well.
+	c.serverName = hs.hello.serverName
+
 	clientSecret := hs.suite.deriveSecret(handshakeSecret,
 		clientHandshakeTrafficLabel, hs.transcript)
 	c.out.setTrafficSecret(hs.suite, clientSecret)
@@ -510,8 +528,8 @@ func (hs *clientHandshakeStateTLS13) readServerParameters() error {
 	// If the server rejects ECH, then it may send retry configurations. If
 	// present, we must check them for syntactic correctness and abort if they
 	// are not correct.
-	if c.ech.offered && len(encryptedExtensions.encryptedClientHello) > 0 {
-		c.ech.retryConfigs = encryptedExtensions.encryptedClientHello
+	if c.ech.offered && len(encryptedExtensions.ech) > 0 {
+		c.ech.retryConfigs = encryptedExtensions.ech
 		if _, err = UnmarshalECHConfigs(c.ech.retryConfigs); err != nil {
 			c.sendAlert(alertIllegalParameter)
 			return fmt.Errorf("tls: ech: failed to parse retry configs: %s", err)

--- a/src/crypto/tls/handshake_server.go
+++ b/src/crypto/tls/handshake_server.go
@@ -141,7 +141,7 @@ func (c *Conn) readClientHello() (*clientHelloMsg, error) {
 	// or GetCertifciate(). Hence, it is not currently possible to reject ECH if
 	// we don't recognize the inner SNI. This may or may not be desirable in the
 	// future.
-	clientHello, err = c.echAcceptOrBypass(clientHello)
+	clientHello, err = c.echAcceptOrReject(clientHello)
 	if err != nil {
 		return nil, fmt.Errorf("tls: %s", err) // Alert sent.
 	}

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -174,6 +174,13 @@ func (hs *serverHandshakeStateTLS13) processClientHello() error {
 		return err
 	}
 
+	if hs.clientHello.echIsInner {
+		// If confirming ECH acceptance, then clear the last 8 bytes of the
+		// ServerHello.random in preparation for computing the confirmation
+		// hint.
+		copy(hs.hello.random[24:], []byte{0, 0, 0, 0, 0, 0, 0, 0})
+	}
+
 	if len(hs.clientHello.secureRenegotiation) != 0 {
 		c.sendAlert(alertHandshakeFailure)
 		return errors.New("tls: initial handshake had non-empty renegotiation extension")
@@ -515,7 +522,7 @@ func (hs *serverHandshakeStateTLS13) doHelloRetryRequest(selectedGroup CurveID) 
 		return unexpectedMessageError(clientHello, msg)
 	}
 
-	clientHello, err = c.echAcceptOrBypass(clientHello)
+	clientHello, err = c.echAcceptOrReject(clientHello)
 	if err != nil {
 		return fmt.Errorf("tls: %s", err) // Alert sent
 	}
@@ -600,13 +607,26 @@ func illegalClientHelloChange(ch, ch1 *clientHelloMsg) bool {
 func (hs *serverHandshakeStateTLS13) sendServerParameters() error {
 	c := hs.c
 
+	earlySecret := hs.earlySecret
+	if earlySecret == nil {
+		earlySecret = hs.suite.extract(nil, nil)
+	}
+	hs.handshakeSecret = hs.suite.extract(hs.sharedKey,
+		hs.suite.deriveSecret(earlySecret, "derived", nil))
+
 	// Confirm ECH acceptance.
-	if hs.clientHello.encryptedClientHelloOffered &&
-		len(hs.clientHello.encryptedClientHello) == 0 {
-		secret := hs.suite.extract(hs.clientHello.random, nil)
-		context := hs.hello.random[:24]
-		acceptConfirmation := hs.suite.expandLabel(secret, echTls13LabelAcceptConfirm, context, 8)
-		copy(hs.hello.random[24:], acceptConfirmation)
+	if hs.clientHello.echIsInner {
+		confTranscript := cloneHash(hs.transcript, hs.suite.hash)
+		if confTranscript == nil {
+			c.sendAlert(alertInternalError)
+			return errors.New("tls: internal error: failed to clone hash")
+		}
+		confTranscript.Write(hs.clientHello.marshal())
+		confTranscript.Write(hs.hello.marshal())
+		conf := hs.suite.deriveSecret(hs.handshakeSecret,
+			echAcceptConfirmationLabel, confTranscript)
+		copy(hs.hello.random[24:], conf[:8])
+		hs.hello.raw = nil
 	}
 
 	hs.transcript.Write(hs.clientHello.marshal())
@@ -620,13 +640,6 @@ func (hs *serverHandshakeStateTLS13) sendServerParameters() error {
 	if err := hs.sendDummyChangeCipherSpec(); err != nil {
 		return err
 	}
-
-	earlySecret := hs.earlySecret
-	if earlySecret == nil {
-		earlySecret = hs.suite.extract(nil, nil)
-	}
-	hs.handshakeSecret = hs.suite.extract(hs.sharedKey,
-		hs.suite.deriveSecret(earlySecret, "derived", nil))
 
 	clientSecret := hs.suite.deriveSecret(hs.handshakeSecret,
 		clientHandshakeTrafficLabel, hs.transcript)
@@ -655,8 +668,8 @@ func (hs *serverHandshakeStateTLS13) sendServerParameters() error {
 		}
 	}
 
-	if len(c.ech.retryConfigs) > 0 {
-		encryptedExtensions.encryptedClientHello = c.ech.retryConfigs
+	if !c.ech.accepted && len(c.ech.retryConfigs) > 0 {
+		encryptedExtensions.ech = c.ech.retryConfigs
 	}
 
 	hs.transcript.Write(encryptedExtensions.marshal())

--- a/src/crypto/tls/hpke.go
+++ b/src/crypto/tls/hpke.go
@@ -4,81 +4,42 @@
 package tls
 
 import (
-	"crypto/tls/internal/hpke"
+	"circl/hpke"
 	"errors"
 	"fmt"
 )
 
+// The mandatory-to-implement HPKE cipher suite for use with the ECH extension.
+var defaultHPKESuite hpke.Suite
+
 const (
-	// Supported KEMs
-	hpkeKemDhKemX25519HkdfSha256 = uint16(hpke.DHKEM_X25519)
-	hpkeKemDhKemP256kdfSha256    = uint16(hpke.DHKEM_P256)
-
-	// Supported KDFs
-	hpkeKdfHkdfSha256 = uint16(hpke.KDF_HKDF_SHA256)
-	hpkeKdfHkdfSha384 = uint16(hpke.KDF_HKDF_SHA384)
-
-	// Supported AEADs
-	hpkeAeadAes128Gcm        = uint16(hpke.AEAD_AESGCM128)
-	hpkeAeadChaCha20Poly1305 = uint16(hpke.AEAD_CHACHA20POLY1305)
-
-	// Stand-in values for algorithms that are unknown prior to a particular
-	// operation. Note that these are mandatory-to-implement algorithms for ECH
-	// since draft-ietf-tls-esni-08.
-	//
-	// There is a slight mismatch between the API exported by HPKE and the API
-	// required to implement the ECH logic in the TLS stack. Namely, an "HPKE
-	// ciphersuite" is a (KEM, KDF, AEAD) triple, and as such, the API of the
-	// HPKE implementation we use, github.com/cisco/go-hpke, presumes all three
-	// algorithms are known prior to any HPKE operation. In contrast, an "ECH
-	// ciphersuite" is a (KDF, AEAD) pair, meaning the KDF and AEAD may not be
-	// known when doing a KEM operation, e.g., generating a KEM key pair. This
-	// library provides a thin wrapper around github.com/cisco/go-hpke that
-	// resolves this mismatch.
-	dummyKemId  = hpkeKemDhKemX25519HkdfSha256
-	dummyKdfId  = hpkeKdfHkdfSha256
-	dummyAeadId = hpkeAeadAes128Gcm
-
-	// The ciphertext expansion incurred by the AEAD identified by dummyAeadId.
-	dummyAeadOverheadLen = 16
-
-	// The output size of "Expand()" for the KDF identified by dummyKdfId.
-	dummyKdfOutputLen = 32
+	defaultHPKESuiteTagLen int = 16 // AEAD_AES128GCM
 )
 
-func init() {
-	// Ensure that this package supports the mandatory-to-implement cipher suite
-	// for the ECH extension.
-	_, err := hpkeAssembleCipherSuite(hpkeKemDhKemX25519HkdfSha256, hpkeKdfHkdfSha256, hpkeAeadAes128Gcm)
-	if err != nil {
-		panic(fmt.Errorf("internal error: ech: failed to assemble MTI cipher suite: %s", err))
+func hpkeAssembleSuite(kemId, kdfId, aeadId uint16) (hpke.Suite, error) {
+	kem := hpke.KEM(kemId)
+	if !kem.IsValid() {
+		return hpke.Suite{}, errors.New("KEM is not supported")
 	}
+	kdf := hpke.KDF(kdfId)
+	if !kdf.IsValid() {
+		return hpke.Suite{}, errors.New("KDF is not supported")
+	}
+	aead := hpke.AEAD(aeadId)
+	if !aead.IsValid() {
+		return hpke.Suite{}, errors.New("AEAD is not supported")
+	}
+	return hpke.NewSuite(kem, kdf, aead), nil
 }
 
-// hpkeAssembleHpkeCipherSuite maps the codepoints for an HPKE ciphersuite to
-// the ciphersuite's internal representation, verifying that the host supports
-// the cipher suite.
-//
-// NOTE: draft-irtf-cfrg-hpke-05 reserves the `0x0000` code point for dummy KEM,
-// KDF, and AEAD identifiers. `AssembleCipherSuite` interprets '0x0000' as an
-// invalid algorithm.
-func hpkeAssembleCipherSuite(kemId, kdfId, aeadId uint16) (hpke.CipherSuite, error) {
-	if kemId != hpkeKemDhKemX25519HkdfSha256 &&
-		kemId != hpkeKemDhKemP256kdfSha256 {
-		return hpke.CipherSuite{}, errors.New("KEM not supported")
+func init() {
+	var err error
+	defaultHPKESuite, err = hpkeAssembleSuite(
+		uint16(hpke.KEM_X25519_HKDF_SHA256),
+		uint16(hpke.KDF_HKDF_SHA256),
+		uint16(hpke.AEAD_AES128GCM),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("hpke: mandatory-to-implement cipher suite not supported: %s", err))
 	}
-
-	if kdfId != hpkeKdfHkdfSha256 &&
-		kdfId != hpkeKdfHkdfSha384 {
-		return hpke.CipherSuite{}, errors.New("KDF not supported")
-	}
-
-	if aeadId != hpkeAeadAes128Gcm &&
-		aeadId != hpkeAeadChaCha20Poly1305 {
-		return hpke.CipherSuite{}, errors.New("AEAD not supported")
-	}
-
-	// Verify that the ciphersuite is supported by github.com/cisco/go-hpke and
-	// return the ciphersuite's internal representation.
-	return hpke.AssembleCipherSuite(hpke.KEMID(kemId), hpke.KDFID(kdfId), hpke.AEADID(aeadId))
 }

--- a/src/crypto/tls/tls.go
+++ b/src/crypto/tls/tls.go
@@ -6,7 +6,7 @@
 // and TLS 1.3, as specified in RFC 8446.
 //
 // This package implements the "Encrypted ClientHello (ECH)" extension, as
-// specified by draft-ietf-tls-esni-08. This extension allows the client to
+// specified by draft-ietf-tls-esni-09. This extension allows the client to
 // encrypt its ClientHello to the public key of an ECH-service provider, known
 // as the client-facing server. If successful, then the client-facing server
 // forwards the decrypted ClientHello to the intended recipient, known as the
@@ -15,19 +15,19 @@
 package tls
 
 // BUG(cjpatton): In order to achieve its security goal, the ECH extension
-// specifies various padding mechanisms to ensure that the length of handshake
-// messages doesn't depend on who terminates the connection. This package does
-// not yet implement client- or server-side padding.
+// requires padding in order to ensure that the length of handshake messages
+// doesn't depend on who terminates the connection. This package does not yet
+// implement client- or server-side padding: see
+// https://github.com/tlswg/draft-ietf-tls-esni/issues/264.
 
-// BUG(cjpatton): Another goal of the ECH extension is that connections that use
-// ECH should be indistinguishable from connections that provide covertext in
-// the form of a "GREASE" ECH extension. This property is known informally as
-// "don't stick out". Providing this property requires additional padding, which
-// this package does not yet implement.
+// BUG(cjpatton): Another goal of the ECH extension is that connections that
+// middleboxes shouldn't differentiate between the real ECH protocol and the
+// "grease ECH" protocol wherein the client generates a dummy ECH extension,
+// which the server is expected to ignore. The ECH specification is subject to
+// change as this "don't stick out" property is worked out in more detail.
 
-// BUG(cjpatton): The interaction of the  ECH extension interacts with PSK has
-// not yet been fully vetted. For now, the server disables session tickets if
-// ECH is enabled.
+// BUG(cjpatton): The interaction of the ECH extension with PSK has not yet been
+// fully vetted. For now, the server disables session tickets if ECH is enabled.
 
 // BUG(cjpatton): Upon ECH rejection, if retry configurations are provided, then
 // the client is expected to retry the connection.  Otherwise, it may regard ECH
@@ -36,8 +36,8 @@ package tls
 
 // BUG(cjpatton): If the client offers the ECH extension and the client-facing
 // server rejects it, then only the client-facing server is authenticated. In
-// particular, the client is expected to responds to a CertificateRequest with
-// an empty certificate. This package does not yet implement this behavior.
+// particular, the client is expected to respond to a CertificateRequest with an
+// empty certificate. This package does not yet implement this behavior.
 
 // BUG(agl): The crypto/tls package only implements some countermeasures
 // against Lucky13 attacks on CBC-mode encryption, and only on SHA1


### PR DESCRIPTION
Most significant spec changes include:
- Bump HPKE-05 to -07.
- Derive acceptance confirmation from handshake secret.
- Reuse HPKE context across HRR.
- Use a new codepoint to distinguish between CHI/CHO.
- Bind context handle to AEAD encryption.

Other changes:
- Remove hrrPsk from ECHProvider.Context (breaks API).
- Prune retry configs of unknown version returned by the ECH provider.
- Add EXP_ECHKeySet, a default implementation of the ECH provider. (This
  will be useful for interop testing.)
- Require that the ECH extension not appear in OuterExtensions.
- Add event handler for outer SNI / public name mismatch.

**NOTE:** This change was already reviewed here: #38. I merged the code into the wrong branch, so this PR just merges the same code into master.