### PR TITLE
crypto/tls: Fix a bug in client-side ECH logic

### DIFF
--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -456,12 +456,12 @@ func (hs *clientHandshakeStateTLS13) establishHandshakeKeys() error {
 			c.sendAlert(alertInternalError)
 			return errors.New("tls: internal error: failed to clone hash")
 		}
-		var random [32]byte // initialized to zero
-		copy(random[:24], hs.serverHello.random[:24])
-		serverHelloConf := *hs.serverHello
-		serverHelloConf.raw = nil
-		serverHelloConf.random = random[:]
-		confTranscript.Write(serverHelloConf.marshal())
+		serverHelloConf := echEncodeServerHelloConf(hs.serverHello.marshal())
+		if serverHelloConf == nil {
+			c.sendAlert(alertInternalError)
+			return errors.New("tls: internal error: failed to encode ServerHelloConf")
+		}
+		confTranscript.Write(serverHelloConf)
 		conf := hs.suite.deriveSecret(handshakeSecret,
 			echAcceptConfirmationLabel, confTranscript)
 		if bytes.Equal(hs.serverHello.random[24:], conf[:8]) {


### PR DESCRIPTION
When constructing the ServerHelloConf string, the client may re-order
the ServerHello extensions, causing the client to presume the
ClientHelloOuter was used. Because their transcripts don't match, the
client aborts with a "bad record MAC" alert.

This bug is a result of the manner in which the client computes this
string. It first unmarshals the ServerHello, overwrites the last 8 bytes
of ServerHello.random, then marshals the result the same way the server
marshals its ServerHello, but the extensions may appear in a different
order.

The solution was to write a dedicated function for encoding mapping the
ServerHello to the ServerHelloConf.