### PR TITLE
crypto/tls: Consolidate Cloudflare-specific features

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -742,12 +742,12 @@ type Config struct {
 	// payload.
 	ServerECHProvider ECHProvider
 
-	// EXP_EventHandler, if set, is called by the client and server at various
+	// CFEventHandler, if set, is called by the client and server at various
 	// points during the handshake to handle specific events. For example, this
 	// callback can be used to record metrics.
 	//
 	// NOTE: This API is EXPERIMENTAL and subject to change.
-	EXP_EventHandler func(event EXP_Event)
+	CFEventHandler func(event CFEvent)
 
 	// mutex protects sessionTicketKeys and autoSessionTicketKeys.
 	mutex sync.RWMutex
@@ -838,7 +838,7 @@ func (c *Config) Clone() *Config {
 		ECHEnabled:                  c.ECHEnabled,
 		ClientECHConfigs:            c.ClientECHConfigs,
 		ServerECHProvider:           c.ServerECHProvider,
-		EXP_EventHandler:            c.EXP_EventHandler,
+		CFEventHandler:              c.CFEventHandler,
 		sessionTicketKeys:           c.sessionTicketKeys,
 		autoSessionTicketKeys:       c.autoSessionTicketKeys,
 	}

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -328,6 +328,13 @@ type ConnectionState struct {
 	// accepted by the server.
 	ECHAccepted bool
 
+	// CFControl is used to pass additional TLS configuration information to
+	// HTTP requests.
+	//
+	// NOTE: This feature is used to implement Cloudflare-internal features.
+	// This feature is unstable and applications MUST NOT depend on it.
+	CFControl interface{}
+
 	// ekm is a closure exposed via ExportKeyingMaterial.
 	ekm func(label string, context []byte, length int) ([]byte, error)
 }
@@ -743,9 +750,19 @@ type Config struct {
 	ServerECHProvider ECHProvider
 
 	// CFEventHandler, if set, is called by the client and server at various
-	// points during the handshake to handle specific events. For example, this
-	// callback can be used to record metrics.
+	// points during the handshake to handle specific events. This is used
+	// primarily for collecting metrics.
+	//
+	// NOTE: This feature is used to implement Cloudflare-internal features.
+	// This feature is unstable and applications MUST NOT depend on it.
 	CFEventHandler func(event CFEvent)
+
+	// CFControl is used to pass additional TLS configuration information to
+	// HTTP requests via ConnectionState.
+	//
+	// NOTE: This feature is used to implement Cloudflare-internal features.
+	// This feature is unstable and applications MUST NOT depend on it.
+	CFControl interface{}
 
 	// mutex protects sessionTicketKeys and autoSessionTicketKeys.
 	mutex sync.RWMutex
@@ -837,6 +854,7 @@ func (c *Config) Clone() *Config {
 		ClientECHConfigs:            c.ClientECHConfigs,
 		ServerECHProvider:           c.ServerECHProvider,
 		CFEventHandler:              c.CFEventHandler,
+		CFControl:                   c.CFControl,
 		sessionTicketKeys:           c.sessionTicketKeys,
 		autoSessionTicketKeys:       c.autoSessionTicketKeys,
 	}

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -745,8 +745,6 @@ type Config struct {
 	// CFEventHandler, if set, is called by the client and server at various
 	// points during the handshake to handle specific events. For example, this
 	// callback can be used to record metrics.
-	//
-	// NOTE: This API is EXPERIMENTAL and subject to change.
 	CFEventHandler func(event CFEvent)
 
 	// mutex protects sessionTicketKeys and autoSessionTicketKeys.

--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -1342,23 +1342,23 @@ func (c *Conn) Close() error {
 
 	// Resolve ECH status.
 	if !c.isClient && c.config.MaxVersion < VersionTLS13 {
-		c.handleEvent(EXP_EventECHServerStatus(echStatusBypassed))
+		c.handleCFEvent(CFEventECHServerStatus(echStatusBypassed))
 	} else if !c.ech.offered {
 		if !c.ech.greased {
-			c.handleEvent(EXP_EventECHClientStatus(echStatusBypassed))
+			c.handleCFEvent(CFEventECHClientStatus(echStatusBypassed))
 		} else {
-			c.handleEvent(EXP_EventECHClientStatus(echStatusOuter))
+			c.handleCFEvent(CFEventECHClientStatus(echStatusOuter))
 		}
 	} else {
-		c.handleEvent(EXP_EventECHClientStatus(echStatusInner))
+		c.handleCFEvent(CFEventECHClientStatus(echStatusInner))
 		if !c.ech.accepted {
 			if len(c.ech.retryConfigs) > 0 {
-				c.handleEvent(EXP_EventECHServerStatus(echStatusOuter))
+				c.handleCFEvent(CFEventECHServerStatus(echStatusOuter))
 			} else {
-				c.handleEvent(EXP_EventECHServerStatus(echStatusBypassed))
+				c.handleCFEvent(CFEventECHServerStatus(echStatusBypassed))
 			}
 		} else {
-			c.handleEvent(EXP_EventECHServerStatus(echStatusInner))
+			c.handleCFEvent(CFEventECHServerStatus(echStatusInner))
 		}
 	}
 
@@ -1494,8 +1494,8 @@ func (c *Conn) handshakeComplete() bool {
 	return atomic.LoadUint32(&c.handshakeStatus) == 1
 }
 
-func (c *Conn) handleEvent(event EXP_Event) {
-	if c.config.EXP_EventHandler != nil {
-		c.config.EXP_EventHandler(event)
+func (c *Conn) handleCFEvent(event CFEvent) {
+	if c.config.CFEventHandler != nil {
+		c.config.CFEventHandler(event)
 	}
 }

--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -1448,6 +1448,7 @@ func (c *Conn) connectionStateLocked() ConnectionState {
 	state.SignedCertificateTimestamps = c.scts
 	state.OCSPResponse = c.ocspResponse
 	state.ECHAccepted = c.ech.accepted
+	state.CFControl = c.config.CFControl
 	if !c.didResume && c.vers != VersionTLS13 {
 		if c.clientFinishedIsFirst {
 			state.TLSUnique = c.clientFinished[:]

--- a/src/crypto/tls/ech.go
+++ b/src/crypto/tls/ech.go
@@ -26,67 +26,67 @@ const (
 	echStatusOuter
 )
 
-// EXP_EventECHClientStatus is emitted once it is known whether the client
+// CFEventECHClientStatus is emitted once it is known whether the client
 // bypassed, offered, or greased ECH.
 //
 // NOTE: This API is EXPERIMENTAL and subject to change.
-type EXP_EventECHClientStatus int
+type CFEventECHClientStatus int
 
 // Bypassed returns true if the client bypassed ECH.
-func (e EXP_EventECHClientStatus) Bypassed() bool {
+func (e CFEventECHClientStatus) Bypassed() bool {
 	return e == echStatusBypassed
 }
 
 // Offered returns true if the client offered ECH.
-func (e EXP_EventECHClientStatus) Offered() bool {
+func (e CFEventECHClientStatus) Offered() bool {
 	return e == echStatusInner
 }
 
 // Greased returns true if the client greased ECH.
-func (e EXP_EventECHClientStatus) Greased() bool {
+func (e CFEventECHClientStatus) Greased() bool {
 	return e == echStatusOuter
 }
 
-// Name is required by the EXP_Event interface.
-func (e EXP_EventECHClientStatus) Name() string {
+// Name is required by the CFEvent interface.
+func (e CFEventECHClientStatus) Name() string {
 	return "ech client status"
 }
 
-// EXP_EventECHServerStatus is emitted once it is known whether the client
+// CFEventECHServerStatus is emitted once it is known whether the client
 // bypassed, offered, or greased ECH.
 //
 // NOTE: This API is EXPERIMENTAL and subject to change.
-type EXP_EventECHServerStatus int
+type CFEventECHServerStatus int
 
 // Bypassed returns true if the client bypassed ECH.
-func (e EXP_EventECHServerStatus) Bypassed() bool {
+func (e CFEventECHServerStatus) Bypassed() bool {
 	return e == echStatusBypassed
 }
 
 // Accepted returns true if the client offered ECH.
-func (e EXP_EventECHServerStatus) Accepted() bool {
+func (e CFEventECHServerStatus) Accepted() bool {
 	return e == echStatusInner
 }
 
 // Rejected returns true if the client greased ECH.
-func (e EXP_EventECHServerStatus) Rejected() bool {
+func (e CFEventECHServerStatus) Rejected() bool {
 	return e == echStatusOuter
 }
 
-// Name is required by the EXP_Event interface.
-func (e EXP_EventECHServerStatus) Name() string {
+// Name is required by the CFEvent interface.
+func (e CFEventECHServerStatus) Name() string {
 	return "ech server status"
 }
 
-// EXP_EventECHPublicNameMismatch is emitted if the outer SNI does not match
+// CFEventECHPublicNameMismatch is emitted if the outer SNI does not match
 // match the public name of the ECH configuration. Note that we do not record
 // the outer SNI in order to avoid collecting this potentially sensitive data.
 //
 // NOTE: This API is EXPERIMENTAL and subject to change.
-type EXP_EventECHPublicNameMismatch struct{}
+type CFEventECHPublicNameMismatch struct{}
 
-// Name is required by the EXP_Event interface.
-func (e EXP_EventECHPublicNameMismatch) Name() string {
+// Name is required by the CFEvent interface.
+func (e CFEventECHPublicNameMismatch) Name() string {
 	return "ech public name does not match outer sni"
 }
 
@@ -332,7 +332,7 @@ func (c *Conn) echAcceptOrReject(hello *clientHelloMsg) (*clientHelloMsg, error)
 				}
 			}
 			if !pubNameMatches {
-				c.handleEvent(EXP_EventECHPublicNameMismatch{})
+				c.handleCFEvent(CFEventECHPublicNameMismatch{})
 			}
 		}
 

--- a/src/crypto/tls/ech.go
+++ b/src/crypto/tls/ech.go
@@ -19,76 +19,7 @@ const (
 	// Constants for HPKE operations
 	echHpkeInfoConfigId = "tls ech config id"
 	echHpkeInfoSetup    = "tls ech"
-
-	// Constants for ECH status events
-	echStatusBypassed = 1 + iota
-	echStatusInner
-	echStatusOuter
 )
-
-// CFEventECHClientStatus is emitted once it is known whether the client
-// bypassed, offered, or greased ECH.
-//
-// NOTE: This API is EXPERIMENTAL and subject to change.
-type CFEventECHClientStatus int
-
-// Bypassed returns true if the client bypassed ECH.
-func (e CFEventECHClientStatus) Bypassed() bool {
-	return e == echStatusBypassed
-}
-
-// Offered returns true if the client offered ECH.
-func (e CFEventECHClientStatus) Offered() bool {
-	return e == echStatusInner
-}
-
-// Greased returns true if the client greased ECH.
-func (e CFEventECHClientStatus) Greased() bool {
-	return e == echStatusOuter
-}
-
-// Name is required by the CFEvent interface.
-func (e CFEventECHClientStatus) Name() string {
-	return "ech client status"
-}
-
-// CFEventECHServerStatus is emitted once it is known whether the client
-// bypassed, offered, or greased ECH.
-//
-// NOTE: This API is EXPERIMENTAL and subject to change.
-type CFEventECHServerStatus int
-
-// Bypassed returns true if the client bypassed ECH.
-func (e CFEventECHServerStatus) Bypassed() bool {
-	return e == echStatusBypassed
-}
-
-// Accepted returns true if the client offered ECH.
-func (e CFEventECHServerStatus) Accepted() bool {
-	return e == echStatusInner
-}
-
-// Rejected returns true if the client greased ECH.
-func (e CFEventECHServerStatus) Rejected() bool {
-	return e == echStatusOuter
-}
-
-// Name is required by the CFEvent interface.
-func (e CFEventECHServerStatus) Name() string {
-	return "ech server status"
-}
-
-// CFEventECHPublicNameMismatch is emitted if the outer SNI does not match
-// match the public name of the ECH configuration. Note that we do not record
-// the outer SNI in order to avoid collecting this potentially sensitive data.
-//
-// NOTE: This API is EXPERIMENTAL and subject to change.
-type CFEventECHPublicNameMismatch struct{}
-
-// Name is required by the CFEvent interface.
-func (e CFEventECHPublicNameMismatch) Name() string {
-	return "ech public name does not match outer sni"
-}
 
 // TODO(cjpatton): "[When offering ECH, the client] MUST NOT offer to resume any
 // session for TLS 1.2 and below [in ClientHelloInner]."

--- a/src/crypto/tls/ech_test.go
+++ b/src/crypto/tls/ech_test.go
@@ -533,21 +533,21 @@ type echTestResult struct {
 	// Operational parameters
 	clientDone, serverDone bool
 	// Results
-	clientStatus EXP_EventECHClientStatus
-	serverStatus EXP_EventECHServerStatus
+	clientStatus CFEventECHClientStatus
+	serverStatus CFEventECHServerStatus
 	connState    ConnectionState
 	err          error
 }
 
-func (r *echTestResult) eventHandler(event EXP_Event) {
+func (r *echTestResult) eventHandler(event CFEvent) {
 	switch e := event.(type) {
-	case EXP_EventECHClientStatus:
+	case CFEventECHClientStatus:
 		if r.clientDone {
 			panic("expected at most one client ECH status event")
 		}
 		r.clientStatus = e
 		r.clientDone = true
-	case EXP_EventECHServerStatus:
+	case CFEventECHServerStatus:
 		if r.serverDone {
 			panic("expected at most one server ECH status event")
 		}
@@ -567,7 +567,7 @@ func echTestConn(t *testing.T, clientConfig, serverConfig *Config) (clientRes, s
 	serverCh := make(chan echTestResult, 1)
 	go func() {
 		var res echTestResult
-		serverConfig.EXP_EventHandler = res.eventHandler
+		serverConfig.CFEventHandler = res.eventHandler
 		serverConn, err := ln.Accept()
 		if err != nil {
 			res.err = err
@@ -593,7 +593,7 @@ func echTestConn(t *testing.T, clientConfig, serverConfig *Config) (clientRes, s
 		res.connState = server.ConnectionState()
 	}()
 
-	clientConfig.EXP_EventHandler = clientRes.eventHandler
+	clientConfig.CFEventHandler = clientRes.eventHandler
 	client, err := Dial("tcp", ln.Addr().String(), clientConfig)
 	if err != nil {
 		serverRes = <-serverCh

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -16,48 +16,6 @@ import (
 	"time"
 )
 
-// CFEventTLS13ClientHandshakeTimingInfo carries intra-stack time durations
-// for TLS 1.3 state machine changes. It can be used for tracking metrics during a
-// connection. Some durations may be sensitive, such as the amount of time to
-// process a particular handshake message, so this event should only be used
-// for experimental purposes.
-//
-// NOTE: This API is EXPERIMENTAL and subject to change.
-type CFEventTLS13ClientHandshakeTimingInfo struct {
-	timer                   func() time.Time
-	start                   time.Time
-	WriteClientHello        time.Duration
-	ProcessServerHello      time.Duration
-	ReadEncryptedExtensions time.Duration
-	ReadCertificate         time.Duration
-	ReadCertificateVerify   time.Duration
-	ReadServerFinished      time.Duration
-	WriteCertificate        time.Duration
-	WriteCertificateVerify  time.Duration
-	WriteClientFinished     time.Duration
-}
-
-// Name is required by the CFEvent interface.
-func (e CFEventTLS13ClientHandshakeTimingInfo) Name() string {
-	return "TLS13ClientHandshakeTimingInfo"
-}
-
-func (e CFEventTLS13ClientHandshakeTimingInfo) elapsedTime() time.Duration {
-	return time.Now().Sub(e.start)
-}
-
-func createTLS13ClientHandshakeTimingInfo(timerFunc func() time.Time) CFEventTLS13ClientHandshakeTimingInfo {
-	timer := time.Now
-	if timerFunc != nil {
-		timer = timerFunc
-	}
-
-	return CFEventTLS13ClientHandshakeTimingInfo{
-		timer: timer,
-		start: timer(),
-	}
-}
-
 type clientHandshakeStateTLS13 struct {
 	c           *Conn
 	serverHello *serverHelloMsg

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -16,14 +16,14 @@ import (
 	"time"
 )
 
-// EXP_EventTLS13ClientHandshakeTimingInfo carries intra-stack time durations
+// CFEventTLS13ClientHandshakeTimingInfo carries intra-stack time durations
 // for TLS 1.3 state machine changes. It can be used for tracking metrics during a
 // connection. Some durations may be sensitive, such as the amount of time to
 // process a particular handshake message, so this event should only be used
 // for experimental purposes.
 //
 // NOTE: This API is EXPERIMENTAL and subject to change.
-type EXP_EventTLS13ClientHandshakeTimingInfo struct {
+type CFEventTLS13ClientHandshakeTimingInfo struct {
 	timer                   func() time.Time
 	start                   time.Time
 	WriteClientHello        time.Duration
@@ -37,22 +37,22 @@ type EXP_EventTLS13ClientHandshakeTimingInfo struct {
 	WriteClientFinished     time.Duration
 }
 
-// Name is required by the EXP_Event interface.
-func (e EXP_EventTLS13ClientHandshakeTimingInfo) Name() string {
+// Name is required by the CFEvent interface.
+func (e CFEventTLS13ClientHandshakeTimingInfo) Name() string {
 	return "TLS13ClientHandshakeTimingInfo"
 }
 
-func (e EXP_EventTLS13ClientHandshakeTimingInfo) elapsedTime() time.Duration {
+func (e CFEventTLS13ClientHandshakeTimingInfo) elapsedTime() time.Duration {
 	return time.Now().Sub(e.start)
 }
 
-func createTLS13ClientHandshakeTimingInfo(timerFunc func() time.Time) EXP_EventTLS13ClientHandshakeTimingInfo {
+func createTLS13ClientHandshakeTimingInfo(timerFunc func() time.Time) CFEventTLS13ClientHandshakeTimingInfo {
 	timer := time.Now
 	if timerFunc != nil {
 		timer = timerFunc
 	}
 
-	return EXP_EventTLS13ClientHandshakeTimingInfo{
+	return CFEventTLS13ClientHandshakeTimingInfo{
 		timer: timer,
 		start: timer(),
 	}
@@ -79,7 +79,7 @@ type clientHandshakeStateTLS13 struct {
 	masterSecret    []byte
 	trafficSecret   []byte // client_application_traffic_secret_0
 
-	handshakeTimings EXP_EventTLS13ClientHandshakeTimingInfo
+	handshakeTimings CFEventTLS13ClientHandshakeTimingInfo
 }
 
 // handshake requires hs.c, hs.hello, hs.serverHello, hs.ecdheParams, and,
@@ -155,7 +155,7 @@ func (hs *clientHandshakeStateTLS13) handshake() error {
 		return err
 	}
 
-	c.handleEvent(hs.handshakeTimings)
+	c.handleCFEvent(hs.handshakeTimings)
 	atomic.StoreUint32(&c.handshakeStatus, 1)
 
 	return nil

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -22,48 +22,6 @@ import (
 // messages cause too much work in session ticket decryption attempts.
 const maxClientPSKIdentities = 5
 
-// CFEventTLS13ServerHandshakeTimingInfo carries intra-stack time durations
-// for TLS 1.3 state machine changes. It can be used for tracking metrics during a
-// connection. Some durations may be sensitive, such as the amount of time to
-// process a particular handshake message, so this event should only be used
-// for experimental purposes.
-//
-// NOTE: This API is EXPERIMENTAL and subject to change.
-type CFEventTLS13ServerHandshakeTimingInfo struct {
-	timer                    func() time.Time
-	start                    time.Time
-	ProcessClientHello       time.Duration
-	WriteServerHello         time.Duration
-	WriteEncryptedExtensions time.Duration
-	WriteCertificate         time.Duration
-	WriteCertificateVerify   time.Duration
-	WriteServerFinished      time.Duration
-	ReadCertificate          time.Duration
-	ReadCertificateVerify    time.Duration
-	ReadClientFinished       time.Duration
-}
-
-// Name is required by the CFEvent interface.
-func (e CFEventTLS13ServerHandshakeTimingInfo) Name() string {
-	return "TLS13ServerHandshakeTimingInfo"
-}
-
-func (e CFEventTLS13ServerHandshakeTimingInfo) elapsedTime() time.Duration {
-	return e.timer().Sub(e.start)
-}
-
-func createTLS13ServerHandshakeTimingInfo(timerFunc func() time.Time) CFEventTLS13ServerHandshakeTimingInfo {
-	timer := time.Now
-	if timerFunc != nil {
-		timer = timerFunc
-	}
-
-	return CFEventTLS13ServerHandshakeTimingInfo{
-		timer: timer,
-		start: timer(),
-	}
-}
-
 type serverHandshakeStateTLS13 struct {
 	c               *Conn
 	clientHello     *clientHelloMsg

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -22,14 +22,14 @@ import (
 // messages cause too much work in session ticket decryption attempts.
 const maxClientPSKIdentities = 5
 
-// EXP_EventTLS13ServerHandshakeTimingInfo carries intra-stack time durations
+// CFEventTLS13ServerHandshakeTimingInfo carries intra-stack time durations
 // for TLS 1.3 state machine changes. It can be used for tracking metrics during a
 // connection. Some durations may be sensitive, such as the amount of time to
 // process a particular handshake message, so this event should only be used
 // for experimental purposes.
 //
 // NOTE: This API is EXPERIMENTAL and subject to change.
-type EXP_EventTLS13ServerHandshakeTimingInfo struct {
+type CFEventTLS13ServerHandshakeTimingInfo struct {
 	timer                    func() time.Time
 	start                    time.Time
 	ProcessClientHello       time.Duration
@@ -43,22 +43,22 @@ type EXP_EventTLS13ServerHandshakeTimingInfo struct {
 	ReadClientFinished       time.Duration
 }
 
-// Name is required by the EXP_Event interface.
-func (e EXP_EventTLS13ServerHandshakeTimingInfo) Name() string {
+// Name is required by the CFEvent interface.
+func (e CFEventTLS13ServerHandshakeTimingInfo) Name() string {
 	return "TLS13ServerHandshakeTimingInfo"
 }
 
-func (e EXP_EventTLS13ServerHandshakeTimingInfo) elapsedTime() time.Duration {
+func (e CFEventTLS13ServerHandshakeTimingInfo) elapsedTime() time.Duration {
 	return e.timer().Sub(e.start)
 }
 
-func createTLS13ServerHandshakeTimingInfo(timerFunc func() time.Time) EXP_EventTLS13ServerHandshakeTimingInfo {
+func createTLS13ServerHandshakeTimingInfo(timerFunc func() time.Time) CFEventTLS13ServerHandshakeTimingInfo {
 	timer := time.Now
 	if timerFunc != nil {
 		timer = timerFunc
 	}
 
-	return EXP_EventTLS13ServerHandshakeTimingInfo{
+	return CFEventTLS13ServerHandshakeTimingInfo{
 		timer: timer,
 		start: timer(),
 	}
@@ -81,7 +81,7 @@ type serverHandshakeStateTLS13 struct {
 	transcript      hash.Hash
 	clientFinished  []byte
 
-	handshakeTimings EXP_EventTLS13ServerHandshakeTimingInfo
+	handshakeTimings CFEventTLS13ServerHandshakeTimingInfo
 }
 
 func (hs *serverHandshakeStateTLS13) handshake() error {
@@ -120,7 +120,7 @@ func (hs *serverHandshakeStateTLS13) handshake() error {
 		return err
 	}
 
-	c.handleEvent(hs.handshakeTimings)
+	c.handleCFEvent(hs.handshakeTimings)
 	atomic.StoreUint32(&c.handshakeStatus, 1)
 
 	return nil

--- a/src/crypto/tls/metrics_test.go
+++ b/src/crypto/tls/metrics_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 type testTimingInfo struct {
-	serverTimingInfo EXP_EventTLS13ServerHandshakeTimingInfo
-	clientTimingInfo EXP_EventTLS13ClientHandshakeTimingInfo
+	serverTimingInfo CFEventTLS13ServerHandshakeTimingInfo
+	clientTimingInfo CFEventTLS13ClientHandshakeTimingInfo
 }
 
 func (t testTimingInfo) isMonotonicallyIncreasing() bool {
@@ -41,11 +41,11 @@ func (t testTimingInfo) isMonotonicallyIncreasing() bool {
 	return (serverIsMonotonicallyIncreasing && clientIsMonotonicallyIncreasing)
 }
 
-func (r *testTimingInfo) eventHandler(event EXP_Event) {
+func (r *testTimingInfo) eventHandler(event CFEvent) {
 	switch e := event.(type) {
-	case EXP_EventTLS13ServerHandshakeTimingInfo:
+	case CFEventTLS13ServerHandshakeTimingInfo:
 		r.serverTimingInfo = e
-	case EXP_EventTLS13ClientHandshakeTimingInfo:
+	case CFEventTLS13ClientHandshakeTimingInfo:
 		r.clientTimingInfo = e
 	}
 }
@@ -55,8 +55,8 @@ func runHandshake(t *testing.T, clientConfig, serverConfig *Config) (timingState
 	c, s := localPipe(t)
 	errChan := make(chan error)
 
-	clientConfig.EXP_EventHandler = timingState.eventHandler
-	serverConfig.EXP_EventHandler = timingState.eventHandler
+	clientConfig.CFEventHandler = timingState.eventHandler
+	serverConfig.CFEventHandler = timingState.eventHandler
 
 	go func() {
 		cli := Client(c, clientConfig)

--- a/src/crypto/tls/tls_cf.go
+++ b/src/crypto/tls/tls_cf.go
@@ -46,10 +46,10 @@ func init() {
 	}
 }
 
-// EXP_Event is a value emitted at various points in the handshake that is
-// handled by the callback Config.EventHandler.
+// CFEvent is a value emitted at various points in the handshake that is
+// handled by the callback Config.CFEventHandler.
 //
 // NOTE: This API is EXPERIMENTAL and subject to change.
-type EXP_Event interface {
+type CFEvent interface {
 	Name() string
 }

--- a/src/crypto/tls/tls_cf.go
+++ b/src/crypto/tls/tls_cf.go
@@ -1,3 +1,6 @@
+// Copyright 2021 Cloudflare, Inc. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
 package tls
 
 import (

--- a/src/crypto/tls/tls_cf.go
+++ b/src/crypto/tls/tls_cf.go
@@ -5,6 +5,14 @@ import (
 	circlSign "circl/sign"
 
 	"circl/sign/eddilithium3"
+	"time"
+)
+
+const (
+	// Constants for ECH status events.
+	echStatusBypassed = 1 + iota
+	echStatusInner
+	echStatusOuter
 )
 
 // To add a signature scheme from Circl
@@ -48,8 +56,144 @@ func init() {
 
 // CFEvent is a value emitted at various points in the handshake that is
 // handled by the callback Config.CFEventHandler.
-//
-// NOTE: This API is EXPERIMENTAL and subject to change.
 type CFEvent interface {
 	Name() string
+}
+
+// CFEventTLS13ClientHandshakeTimingInfo carries intra-stack time durations for
+// TLS 1.3 client-state machine changes. It can be used for tracking metrics
+// during a connection. Some durations may be sensitive, such as the amount of
+// time to process a particular handshake message, so this event should only be
+// used for experimental purposes.
+type CFEventTLS13ClientHandshakeTimingInfo struct {
+	timer                   func() time.Time
+	start                   time.Time
+	WriteClientHello        time.Duration
+	ProcessServerHello      time.Duration
+	ReadEncryptedExtensions time.Duration
+	ReadCertificate         time.Duration
+	ReadCertificateVerify   time.Duration
+	ReadServerFinished      time.Duration
+	WriteCertificate        time.Duration
+	WriteCertificateVerify  time.Duration
+	WriteClientFinished     time.Duration
+}
+
+// Name is required by the CFEvent interface.
+func (e CFEventTLS13ClientHandshakeTimingInfo) Name() string {
+	return "TLS13ClientHandshakeTimingInfo"
+}
+
+func (e CFEventTLS13ClientHandshakeTimingInfo) elapsedTime() time.Duration {
+	return time.Now().Sub(e.start)
+}
+
+func createTLS13ClientHandshakeTimingInfo(timerFunc func() time.Time) CFEventTLS13ClientHandshakeTimingInfo {
+	timer := time.Now
+	if timerFunc != nil {
+		timer = timerFunc
+	}
+
+	return CFEventTLS13ClientHandshakeTimingInfo{
+		timer: timer,
+		start: timer(),
+	}
+}
+
+// CFEventTLS13ServerHandshakeTimingInfo carries intra-stack time durations
+// for TLS 1.3 state machine changes. It can be used for tracking metrics during a
+// connection. Some durations may be sensitive, such as the amount of time to
+// process a particular handshake message, so this event should only be used
+// for experimental purposes.
+type CFEventTLS13ServerHandshakeTimingInfo struct {
+	timer                    func() time.Time
+	start                    time.Time
+	ProcessClientHello       time.Duration
+	WriteServerHello         time.Duration
+	WriteEncryptedExtensions time.Duration
+	WriteCertificate         time.Duration
+	WriteCertificateVerify   time.Duration
+	WriteServerFinished      time.Duration
+	ReadCertificate          time.Duration
+	ReadCertificateVerify    time.Duration
+	ReadClientFinished       time.Duration
+}
+
+// Name is required by the CFEvent interface.
+func (e CFEventTLS13ServerHandshakeTimingInfo) Name() string {
+	return "TLS13ServerHandshakeTimingInfo"
+}
+
+func (e CFEventTLS13ServerHandshakeTimingInfo) elapsedTime() time.Duration {
+	return e.timer().Sub(e.start)
+}
+
+func createTLS13ServerHandshakeTimingInfo(timerFunc func() time.Time) CFEventTLS13ServerHandshakeTimingInfo {
+	timer := time.Now
+	if timerFunc != nil {
+		timer = timerFunc
+	}
+
+	return CFEventTLS13ServerHandshakeTimingInfo{
+		timer: timer,
+		start: timer(),
+	}
+}
+
+// CFEventECHClientStatus is emitted once it is known whether the client
+// bypassed, offered, or greased ECH.
+type CFEventECHClientStatus int
+
+// Bypassed returns true if the client bypassed ECH.
+func (e CFEventECHClientStatus) Bypassed() bool {
+	return e == echStatusBypassed
+}
+
+// Offered returns true if the client offered ECH.
+func (e CFEventECHClientStatus) Offered() bool {
+	return e == echStatusInner
+}
+
+// Greased returns true if the client greased ECH.
+func (e CFEventECHClientStatus) Greased() bool {
+	return e == echStatusOuter
+}
+
+// Name is required by the CFEvent interface.
+func (e CFEventECHClientStatus) Name() string {
+	return "ech client status"
+}
+
+// CFEventECHServerStatus is emitted once it is known whether the client
+// bypassed, offered, or greased ECH.
+type CFEventECHServerStatus int
+
+// Bypassed returns true if the client bypassed ECH.
+func (e CFEventECHServerStatus) Bypassed() bool {
+	return e == echStatusBypassed
+}
+
+// Accepted returns true if the client offered ECH.
+func (e CFEventECHServerStatus) Accepted() bool {
+	return e == echStatusInner
+}
+
+// Rejected returns true if the client greased ECH.
+func (e CFEventECHServerStatus) Rejected() bool {
+	return e == echStatusOuter
+}
+
+// Name is required by the CFEvent interface.
+func (e CFEventECHServerStatus) Name() string {
+	return "ech server status"
+}
+
+// CFEventECHPublicNameMismatch is emitted if the outer SNI does not match
+// match the public name of the ECH configuration. Note that we do not record
+// the outer SNI in order to avoid collecting this potentially sensitive data.
+type CFEventECHPublicNameMismatch struct{}
+
+// Name is required by the CFEvent interface.
+func (e CFEventECHPublicNameMismatch) Name() string {
+	return "ech public name does not match outer sni"
 }

--- a/src/crypto/tls/tls_cf_test.go
+++ b/src/crypto/tls/tls_cf_test.go
@@ -1,0 +1,19 @@
+package tls
+
+import (
+	"testing"
+)
+
+type testCFControl struct {
+	flags uint64
+}
+
+// Check that CFControl is correctly propagated from Config to ConnectionState.
+func TestPropagateCFControl(t *testing.T) {
+	want := uint64(23)
+	s := Server(nil, &Config{CFControl: &testCFControl{want}})
+	got := s.ConnectionState().CFControl.(*testCFControl).flags
+	if got != want {
+		t.Errorf("failed to propagate CFControl: got %v; want %v", got, want)
+	}
+}

--- a/src/crypto/tls/tls_test.go
+++ b/src/crypto/tls/tls_test.go
@@ -831,6 +831,8 @@ func TestCloneNonFuncFields(t *testing.T) {
 			f.Set(reflect.ValueOf([]ECHConfig{ECHConfig{}}))
 		case "ECHEnabled":
 			f.Set(reflect.ValueOf(true))
+		case "CFControl":
+			f.Set(reflect.ValueOf(&testCFControl{23}))
 		default:
 			t.Errorf("all fields must be accounted for, but saw unknown field %q", fn)
 		}

--- a/src/crypto/tls/tls_test.go
+++ b/src/crypto/tls/tls_test.go
@@ -790,7 +790,7 @@ func TestCloneNonFuncFields(t *testing.T) {
 		switch fn := typ.Field(i).Name; fn {
 		case "Rand":
 			f.Set(reflect.ValueOf(io.Reader(os.Stdin)))
-		case "Time", "GetCertificate", "GetConfigForClient", "VerifyPeerCertificate", "VerifyConnection", "GetClientCertificate", "ServerECHProvider", "EXP_EventHandler":
+		case "Time", "GetCertificate", "GetConfigForClient", "VerifyPeerCertificate", "VerifyConnection", "GetClientCertificate", "ServerECHProvider", "CFEventHandler":
 			// DeepEqual can't compare functions. If you add a
 			// function field to this list, you must also change
 			// TestCloneFuncFields to ensure that the func field is


### PR DESCRIPTION
This PR adds a parameter to `crypto/tls.Config`, called `CFControl`, which will be used to implement Cloudflare-internal functionalities.

This is the second such feature that we've added to the `crypto/tls` package. In particular, the `EXP_EventHandler` callback in `crypto/tls.Config` is used for computing metrics that WE are interested in, but are not likely to be useful for upstream Go. To emphasize this, this PR renames the callback to `CFEventHandler` and moves all implementations to `tls_cf.go`. The implementations are also renamed accordingly.