### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+* @armfazh @cjpatton @claucece @Lekensteyn @wbl
+src/circl @armfazh
+src/crypto/tls @claucece @Lekensteyn
+src/crypto/x509 @wbl @cjpatton
+src/internal/cpu @armfazh
+src/net/http @Lekensteyn


### PR DESCRIPTION
Partially solves #56.

Establishes SMEs for heavy-touch packages and sets everyone as the SME for everything else. Please check for syntactical and semantic correctness.