### PR TITLE
Implement ECH-10.

### DIFF
--- a/src/circl/hpke/hpke.go
+++ b/src/circl/hpke/hpke.go
@@ -22,7 +22,7 @@ import (
 	"circl/kem"
 )
 
-const versionLabel = "HPKE-07"
+const versionLabel = "HPKE-v1"
 
 // Context defines the capabilities of an HPKE context.
 type Context interface {

--- a/src/circl/hpke/vectors_test.go
+++ b/src/circl/hpke/vectors_test.go
@@ -15,8 +15,8 @@ import (
 
 func TestVectors(t *testing.T) {
 	// Test vectors from
-	// https://github.com/cfrg/draft-irtf-cfrg-hpke/blob/draft-irtf-cfrg-hpke-07/test-vectors.json
-	vectors := readFile(t, "testdata/vectors_v07.json")
+	// https://github.com/cfrg/draft-irtf-cfrg-hpke/blob/master/test-vectors.json
+	vectors := readFile(t, "testdata/vectors_v08_779d028.json")
 	for i, v := range vectors {
 		t.Run(fmt.Sprintf("v%v", i), v.verify)
 	}

--- a/src/circl/oprf/client.go
+++ b/src/circl/oprf/client.go
@@ -3,6 +3,8 @@ package oprf
 import (
 	"crypto/rand"
 	"errors"
+
+	"circl/group"
 )
 
 // Client is a representation of a OPRF client during protocol execution.
@@ -13,9 +15,22 @@ type Client struct {
 
 // ClientRequest is a structure to encapsulate the output of a Request call.
 type ClientRequest struct {
-	inputs          [][]byte
-	blinds          []Blind
-	BlindedElements []Blinded
+	inputs   [][]byte
+	blinds   []Blind
+	elements []group.Element
+}
+
+// BlindedElements returns the serialized blinded elements produced for the client request.
+func (r ClientRequest) BlindedElements() [][]byte {
+	var err error
+	serializedBlinds := make([][]byte, len(r.elements))
+	for i := range r.elements {
+		serializedBlinds[i], err = r.elements[i].MarshalBinaryCompress()
+		if err != nil {
+			return nil
+		}
+	}
+	return serializedBlinds
 }
 
 // NewClient creates a client in base mode.
@@ -58,14 +73,11 @@ func (c *Client) Request(inputs [][]byte) (*ClientRequest, error) {
 }
 
 func (c *Client) blind(inputs [][]byte, blinds []Blind) (*ClientRequest, error) {
-	var err error
-	blindedElements := make([]Blinded, len(inputs))
+	blindedElements := make([]group.Element, len(inputs))
 	for i := range inputs {
 		p := c.suite.Group.HashToElement(inputs[i], c.suite.getDST(hashToGroupDST))
-		blindedElements[i], err = c.scalarMult(p, blinds[i])
-		if err != nil {
-			return nil, err
-		}
+		blindedElements[i] = c.suite.Group.NewElement()
+		blindedElements[i].Mul(p, blinds[i])
 	}
 	return &ClientRequest{inputs, blinds, blindedElements}, nil
 }
@@ -75,17 +87,27 @@ func (c *Client) blind(inputs [][]byte, blinds []Blind) (*ClientRequest, error) 
 // to verify the proof in verifiable mode.
 func (c *Client) Finalize(r *ClientRequest, e *Evaluation) ([][]byte, error) {
 	l := len(r.blinds)
-	if len(r.BlindedElements) != l || len(e.Elements) != l {
+	if len(r.elements) != l || len(e.Elements) != l {
 		return nil, errors.New("mismatch number of elements")
 	}
 
+	var err error
+	evals := make([]group.Element, len(e.Elements))
+	for i := range e.Elements {
+		evals[i] = c.suite.Group.NewElement()
+		err = evals[i].UnmarshalBinary(e.Elements[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if c.Mode == VerifiableMode {
-		if !c.verifyProof(r.BlindedElements, e) {
+		if !c.verifyProof(r.elements, evals, *e.Proof) {
 			return nil, errors.New("invalid proof")
 		}
 	}
 
-	unblindedElements, err := c.unblind(e.Elements, r.blinds)
+	unblindedElements, err := c.unblind(evals, r.blinds)
 	if err != nil {
 		return nil, err
 	}
@@ -96,29 +118,29 @@ func (c *Client) Finalize(r *ClientRequest, e *Evaluation) ([][]byte, error) {
 	return outputs, nil
 }
 
-func (c *Client) verifyProof(blinds []Blinded, e *Evaluation) bool {
+func (c *Client) verifyProof(blinds []group.Element, elements []group.Element, proof Proof) bool {
 	pkSm, err := c.pkS.Serialize()
 	if err != nil {
 		return false
 	}
-	a0, a1, err := c.computeComposites(pkSm, blinds, e.Elements, nil)
+
+	M, Z, err := c.computeComposites(nil, c.pkS.e, blinds, elements)
 	if err != nil {
 		return false
 	}
-	M := c.suite.Group.NewElement()
-	err = M.UnmarshalBinary(a0)
+
+	a0, err := M.MarshalBinaryCompress()
 	if err != nil {
 		return false
 	}
-	Z := c.suite.Group.NewElement()
-	err = Z.UnmarshalBinary(a1)
+	a1, err := Z.MarshalBinaryCompress()
 	if err != nil {
 		return false
 	}
 
 	sG := c.suite.Group.NewElement()
 	ss := c.suite.Group.NewScalar()
-	err = ss.UnmarshalBinary(e.Proof.S)
+	err = ss.UnmarshalBinary(proof.S)
 	if err != nil {
 		return false
 	}
@@ -126,7 +148,7 @@ func (c *Client) verifyProof(blinds []Blinded, e *Evaluation) bool {
 
 	cP := c.suite.Group.NewElement()
 	cc := c.suite.Group.NewScalar()
-	err = cc.UnmarshalBinary(e.Proof.C)
+	err = cc.UnmarshalBinary(proof.C)
 	if err != nil {
 		return false
 	}
@@ -151,17 +173,13 @@ func (c *Client) verifyProof(blinds []Blinded, e *Evaluation) bool {
 	return gotC.IsEqual(cc)
 }
 
-func (c *Client) unblind(e []SerializedElement, blinds []Blind) ([][]byte, error) {
+func (c *Client) unblind(e []group.Element, blinds []Blind) ([][]byte, error) {
+	var err error
 	unblindedElements := make([][]byte, len(e))
-	p := c.Group.NewElement()
 	invBlind := c.Group.NewScalar()
 	for i := range e {
-		err := p.UnmarshalBinary(e[i])
-		if err != nil {
-			return nil, err
-		}
 		invBlind.Inv(blinds[i])
-		unblindedElements[i], err = c.scalarMult(p, invBlind)
+		unblindedElements[i], err = c.scalarMult(e[i], invBlind)
 		if err != nil {
 			return nil, err
 		}

--- a/src/circl/oprf/oprf_test.go
+++ b/src/circl/oprf/oprf_test.go
@@ -93,7 +93,7 @@ func testAPI(t *testing.T, suite oprf.SuiteID, mode oprf.Mode) {
 		t.Fatal("invalid blinding of client: " + err.Error())
 	}
 
-	eval, err := server.Evaluate(cr.BlindedElements)
+	eval, err := server.Evaluate(cr.BlindedElements())
 	if err != nil {
 		t.Fatal("invalid evaluation of server: " + err.Error())
 	}

--- a/src/circl/oprf/vectors_test.go
+++ b/src/circl/oprf/vectors_test.go
@@ -149,13 +149,13 @@ func (v *vector) test(t *testing.T) {
 		clientReq, err := client.blind(inputs, blinds)
 		test.CheckNoErr(t, err, "invalid client request")
 		v.compareLists(t,
-			clientReq.BlindedElements,
+			clientReq.BlindedElements(),
 			toListBytes(t, vi.BlindedElement, "blindedElement"),
 		)
 
 		rr := toScalar(t, client.suite.Group, vi.EvaluationProof.R, "invalid proof random scalar")
 
-		eval, err := server.evaluateWithProofScalar(clientReq.BlindedElements, rr)
+		eval, err := server.evaluateWithProofScalar(clientReq.BlindedElements(), rr)
 		test.CheckNoErr(t, err, "invalid evaluation")
 		v.compareLists(t,
 			eval.Elements,

--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -103,9 +103,9 @@ const (
 	extensionSignatureAlgorithmsCert uint16 = 50
 	extensionKeyShare                uint16 = 51
 	extensionRenegotiationInfo       uint16 = 0xff01
-	extensionECH                     uint16 = 0xfe09 // draft-ietf-tls-esni-09
-	extensionECHIsInner              uint16 = 0xda09 // draft-ietf-tls-esni-09
-	extensionECHOuterExtensions      uint16 = 0xfd00 // draft-ietf-tls-esni-09
+	extensionECH                     uint16 = 0xfe0a // draft-ietf-tls-esni-10
+	extensionECHIsInner              uint16 = 0xda09 // draft-ietf-tls-esni-10
+	extensionECHOuterExtensions      uint16 = 0xfd00 // draft-ietf-tls-esni-10
 )
 
 // TLS signaling cipher suite values

--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -131,10 +131,11 @@ type Conn struct {
 		retryConfigs []byte // The retry configurations
 
 		// The client's state, used in case of HRR.
-		innerRandom []byte         // ClientHelloInner.random
-		publicName  string         // ECHConfig.contents.public_name
-		suite       echCipherSuite // ClientECH.cipher_suite
-		dummy       []byte         // serialized ClientECH when greasing ECH
+		innerRandom []byte                   // ClientHelloInner.random
+		publicName  string                   // ECHConfig.contents.public_name
+		configId    uint8                    // ECHConfig.contents.key_config.config_id
+		suite       hpkeSymmetricCipherSuite // ClientECH.cipher_suite
+		dummy       []byte                   // serialized ClientECH when greasing ECH
 	}
 
 	// Set by the client and server when an HRR message was sent in this

--- a/src/crypto/tls/ech_test.go
+++ b/src/crypto/tls/ech_test.go
@@ -90,34 +90,36 @@ Fy/vytRwyjhHuX9ntc5ArCpwbAmY+oW/4w==
 
 // The ECH keys used by the client-facing server.
 const echTestKeys = `-----BEGIN ECH KEYS-----
-ACA/SG/gkFYqQ0vvrgz8CRtn8QBhUdmJIHrpLRa4MHbjpgBT/gkATwATY2xvdWRm
-bGFyZS1lc25pLmNvbQAgRcve568ZJiCCyZJvwrIx0FIoSCQihzse5EJM36v98BcA
-IAAQAAEAAQABAAMAAgABAAIAAwAAAAAAIOpdZ5c3Q1EIq5eztNrW+7GcUiPKPDhm
-6JqulMAt5NLmAHT+CQBwABNjbG91ZGZsYXJlLWVzbmkuY29tAEEEpVCefVOCJ4vL
-Ae6XXPx/d6w/yu4qP2asEfG/aYceggNFRS13f2FhfmTsFsctRsrfi0KR4fPlE469
-PxZnNLJ8wAAQABAAAQABAAEAAwACAAEAAgADAAAAAA==
+ACDhS0q2cTU1Qzi6hPM4BQ/HLnbEUZyWdY2GbmS0DVkumgBI/goARAAAIAAgi1Tu
+jWJ236k1VAMeRnysKbDigxLpDs/AGdEowK8KiBkABAABAAEAAAATY2xvdWRmbGFy
+ZS1lc25pLmNvbQAAACBmNj/zQe6OT/MR/MM39G6kwMJCJEXpdvTAkbdHErlgXwBI
+/goARAEAIAAgZ1Ru1uyGX6N9HYs5/pAE3KwUXRDBHD0Bdna8oP4uVEwABAABAAEA
+AAATY2xvdWRmbGFyZS1lc25pLmNvbQAA
 -----END ECH KEYS-----`
 
 // A sequence of ECH keys with unsupported versions.
 const echTestInvalidVersionKeys = `-----BEGIN ECH KEYS-----
-ACChoR9Zm0Y7YJLxh4NHlF9cDWOYVdtbpsXNsLbEejCw4gBTvu8ATwATY2xvdWRm
-bGFyZS1lc25pLmNvbQAg3on70PKtaF9Mp5WQghrykTszqKlaX02Pi+WYpbCza1gA
-IAAQAAEAAQABAAMAAgABAAIAAwAAAAA=
+ACDhS0q2cTU1Qzi6hPM4BQ/HLnbEUZyWdY2GbmS0DVkumgBIAfUARAAAIAAgi1Tu
+jWJ236k1VAMeRnysKbDigxLpDs/AGdEowK8KiBkABAABAAEAAAATY2xvdWRmbGFy
+ZS1lc25pLmNvbQAAACBmNj/zQe6OT/MR/MM39G6kwMJCJEXpdvTAkbdHErlgXwBI
+AfUARAEAIAAgZ1Ru1uyGX6N9HYs5/pAE3KwUXRDBHD0Bdna8oP4uVEwABAABAAEA
+AAATY2xvdWRmbGFyZS1lc25pLmNvbQAA
 -----END ECH KEYS-----`
 
 // The sequence of ECH configurations corresponding to echTestKeys.
 const echTestConfigs = `-----BEGIN ECH CONFIGS-----
-AMf+CQBPABNjbG91ZGZsYXJlLWVzbmkuY29tACBFy97nrxkmIILJkm/CsjHQUihI
-JCKHOx7kQkzfq/3wFwAgABAAAQABAAEAAwACAAEAAgADAAAAAP4JAHAAE2Nsb3Vk
-ZmxhcmUtZXNuaS5jb20AQQSlUJ59U4Ini8sB7pdc/H93rD/K7io/ZqwR8b9phx6C
-A0VFLXd/YWF+ZOwWxy1Gyt+LQpHh8+UTjr0/Fmc0snzAABAAEAABAAEAAQADAAIA
-AQACAAMAAAAA
+AJD+CgBEAAAgACCLVO6NYnbfqTVUAx5GfKwpsOKDEukOz8AZ0SjArwqIGQAEAAEA
+AQAAABNjbG91ZGZsYXJlLWVzbmkuY29tAAD+CgBEAQAgACBnVG7W7IZfo30dizn+
+kATcrBRdEMEcPQF2dryg/i5UTAAEAAEAAQAAABNjbG91ZGZsYXJlLWVzbmkuY29t
+AAA=
 -----END ECH CONFIGS-----`
 
 // An invalid sequence of ECH configurations.
 const echTestStaleConfigs = `-----BEGIN ECH CONFIGS-----
-AFP+CQBPABNjbG91ZGZsYXJlLWVzbmkuY29tACDA9Z4YbY7f6HMlsUUhSHdioVr9
-s6vH9g5PPTkgR83MIwAgABAAAQABAAEAAwACAAEAAgADAAAAAA==
+AJD+CgBEAAAgACCNkMISpIMFmPZwDgob/CROvHD93NQFcX4h0SURHTJpRwAEAAEA
+AQAAABNjbG91ZGZsYXJlLWVzbmkuY29tAAD+CgBEAQAgACAH4P9K5l9BJ3aG4QUk
+fTjMWUoeLQZVdTxp5Qe0FWvDQwAEAAEAAQAAABNjbG91ZGZsYXJlLWVzbmkuY29t
+AAA=
 -----END ECH CONFIGS-----`
 
 // echTestProviderAlwaysAbort mocks an ECHProvider that, in response to any
@@ -892,17 +894,16 @@ func TestECHProvider(t *testing.T) {
 	p := echTestLoadKeySet(echTestKeys)
 	t.Run("ok", func(t *testing.T) {
 		handle := []byte{
-			0, 1, 0, 1, 8, 202, 62, 220, 1, 243, 58, 247, 102, 0, 32, 40, 52,
-			167, 167, 21, 125, 151, 32, 250, 255, 1, 125, 206, 103, 62, 96, 189,
-			112, 126, 48, 221, 41, 198, 146, 100, 149, 29, 133, 103, 87, 87, 78,
+			0, 1, 0, 1, 0, 0, 32, 40, 52, 167, 167, 21, 125, 151, 32, 250, 255, 1,
+			125, 206, 103, 62, 96, 189, 112, 126, 48, 221, 41, 198, 146, 100, 149,
+			29, 133, 103, 87, 87, 78,
 		}
 		context := []byte{
-			1, 0, 32, 0, 1, 0, 1, 32, 236, 67, 192, 226, 245, 110, 78, 204, 212,
-			236, 85, 28, 234, 9, 249, 154, 158, 25, 69, 140, 83, 156, 41, 237,
-			146, 108, 142, 83, 130, 231, 162, 53, 16, 80, 114, 44, 28, 184, 124,
-			105, 82, 228, 226, 156, 178, 245, 44, 171, 175, 12, 97, 213, 61,
-			253, 64, 224, 125, 59, 223, 107, 24, 119, 12, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0,
+			1, 0, 32, 0, 1, 0, 1, 32, 36, 168, 201, 89, 6, 5, 216, 41, 55, 71, 51,
+			165, 58, 92, 20, 212, 13, 84, 72, 119, 247, 120, 50, 63, 21, 145, 190,
+			153, 201, 60, 38, 185, 16, 73, 40, 109, 39, 98, 199, 188, 154, 135, 218,
+			81, 43, 179, 83, 22, 108, 12, 225, 52, 73, 49, 74, 108, 22, 100, 11, 244,
+			38, 198, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 		}
 		testECHProvider(t, p, handle, extensionECH, ECHProviderResult{
 			Status:       ECHProviderSuccess,
@@ -912,7 +913,7 @@ func TestECHProvider(t *testing.T) {
 	})
 	t.Run("invalid config id", func(t *testing.T) {
 		handle := []byte{
-			0, 1, 0, 1, 6, 202, 62, 220, 1, 243, 58, 0, 32, 40, 52, 167, 167,
+			0, 1, 0, 1, 255, 202, 62, 220, 1, 243, 58, 0, 32, 40, 52, 167, 167,
 			21, 125, 151, 32, 250, 255, 1, 125, 206, 103, 62, 96, 189, 112, 126,
 			48, 221, 41, 198, 146, 100, 149, 29, 133, 103, 87, 87, 78,
 		}

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -337,7 +337,7 @@ func (hs *clientHandshakeStateTLS13) processHelloRetryRequest() error {
 		}
 		ech.raw = nil
 		ech.handle.raw = nil
-		ech.handle.configId = []byte{1, 2, 3, 4}
+		ech.handle.configId = uint8(0)
 		ech.handle.enc = []byte{1, 2, 3, 4}
 		hs.hello.ech = ech.marshal()
 	}

--- a/src/crypto/tls/handshake_messages.go
+++ b/src/crypto/tls/handshake_messages.go
@@ -127,14 +127,14 @@ func (m *clientHelloMsg) marshal() []byte {
 
 		b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 			if m.echIsOuter {
-				// draft-ietf-tls-esni-09, "encrypted_client_hello"
+				// draft-ietf-tls-esni-10, "encrypted_client_hello"
 				b.AddUint16(extensionECH)
 				b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 					b.AddBytes(m.ech)
 				})
 			}
 			if m.echIsInner {
-				// draft-ietf-tls-esni-09, "ech_is_inner"
+				// draft-ietf-tls-esni-10, "ech_is_inner"
 				b.AddUint16(extensionECHIsInner)
 				b.AddUint16(0)
 			}
@@ -425,13 +425,13 @@ func (m *clientHelloMsg) unmarshal(data []byte) bool {
 
 		switch extension {
 		case extensionECH:
-			// draft-ietf-tls-esni-09, "encrypted_client_hello"
+			// draft-ietf-tls-esni-10, "encrypted_client_hello"
 			if !extData.ReadBytes(&m.ech, len(extData)) {
 				return false
 			}
 			m.echIsOuter = true
 		case extensionECHIsInner:
-			// draft-ietf-tls-esni-09, "ech_is_inner"
+			// draft-ietf-tls-esni-10, "ech_is_inner"
 			if !extData.ReadBytes(&m.ech, len(extData)) {
 				return false
 			}
@@ -921,7 +921,7 @@ func (m *encryptedExtensionsMsg) marshal() []byte {
 				})
 			}
 			if len(m.ech) > 0 {
-				// draft-ietf-tls-esni-09, "encrypted_client_hello"
+				// draft-ietf-tls-esni-10, "encrypted_client_hello"
 				b.AddUint16(extensionECH)
 				b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 					// If the client-facing server rejects ECH, then it may
@@ -967,7 +967,7 @@ func (m *encryptedExtensionsMsg) unmarshal(data []byte) bool {
 			}
 			m.alpnProtocol = string(proto)
 		case extensionECH:
-			// draft-ietf-tls-esni-09
+			// draft-ietf-tls-esni-10
 			if !extData.ReadBytes(&m.ech, len(extData)) {
 				return false
 			}

--- a/src/crypto/tls/tls.go
+++ b/src/crypto/tls/tls.go
@@ -6,7 +6,7 @@
 // and TLS 1.3, as specified in RFC 8446.
 //
 // This package implements the "Encrypted ClientHello (ECH)" extension, as
-// specified by draft-ietf-tls-esni-09. This extension allows the client to
+// specified by draft-ietf-tls-esni-10. This extension allows the client to
 // encrypt its ClientHello to the public key of an ECH-service provider, known
 // as the client-facing server. If successful, then the client-facing server
 // forwards the decrypted ClientHello to the intended recipient, known as the


### PR DESCRIPTION
This change adds support for ECH-10. The primary changes are moving to
HPKE-08 and changing the ECHConfig identifier from a client-computed
value to a server-chosen value. ECHProviders MUST use rejection sampling
in choosing the configuration identifier so as to not introduce conflicts.