### PR TITLE
[cf-pq-kemtls] crypto/tls: reset timings

### DIFF
--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -352,6 +352,9 @@ func (c *Conn) clientHandshake() (err error) {
 		return err
 	}
 
+	// Client already received the serverHello
+	handshakeTimings.reset()
+
 	// If we are negotiating a protocol version that's lower than what we
 	// support, check for the server downgrade canaries.
 	// See RFC 8446, Section 4.1.3.

--- a/src/crypto/tls/handshake_client_kemtls.go
+++ b/src/crypto/tls/handshake_client_kemtls.go
@@ -55,7 +55,8 @@ func (hs *clientHandshakeStateTLS13) handshakeKEMTLS() error {
 		}
 	}
 
-	//hs.handshakeTimings.ExperimentName = experimentName(c)
+	// hs.handshakeTimings.ExperimentName = experimentName(c)
+	hs.handshakeTimings.finish()
 	c.handleCFEvent(hs.handshakeTimings)
 	atomic.StoreUint32(&c.handshakeStatus, 1)
 

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -166,7 +166,8 @@ func (hs *clientHandshakeStateTLS13) handshake() error {
 		return err
 	}
 
-	hs.handshakeTimings.ExperimentName = experimentName(c)
+	// hs.handshakeTimings.ExperimentName = experimentName(c)
+	hs.handshakeTimings.finish()
 	c.handleCFEvent(hs.handshakeTimings)
 	atomic.StoreUint32(&c.handshakeStatus, 1)
 

--- a/src/crypto/tls/handshake_server_kemtls.go
+++ b/src/crypto/tls/handshake_server_kemtls.go
@@ -45,7 +45,8 @@ func (hs *serverHandshakeStateTLS13) handshakeKEMTLS() error {
 		}
 	}
 
-	//hs.handshakeTimings.ExperimentName = experimentName(c)
+	// hs.handshakeTimings.ExperimentName = experimentName(c)
+	hs.handshakeTimings.finish()
 	c.handleCFEvent(hs.handshakeTimings)
 	atomic.StoreUint32(&c.handshakeStatus, 1)
 

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -129,6 +129,8 @@ func (hs *serverHandshakeStateTLS13) handshake() error {
 	if _, err := c.flush(); err != nil {
 		return err
 	}
+	// this is round 2 of server
+	hs.handshakeTimings.reset()
 	if err := hs.readClientCertificate(); err != nil {
 		return err
 	}
@@ -136,7 +138,8 @@ func (hs *serverHandshakeStateTLS13) handshake() error {
 		return err
 	}
 
-	//hs.handshakeTimings.ExperimentName = experimentName(c)
+	// hs.handshakeTimings.ExperimentName = experimentName(c)
+	hs.handshakeTimings.finish()
 	c.handleCFEvent(hs.handshakeTimings)
 
 	atomic.StoreUint32(&c.handshakeStatus, 1)

--- a/src/crypto/tls/metrics_test.go
+++ b/src/crypto/tls/metrics_test.go
@@ -19,24 +19,27 @@ type testTimingInfo struct {
 
 func (t testTimingInfo) isMonotonicallyIncreasing() bool {
 	serverIsMonotonicallyIncreasing :=
-		t.serverTimingInfo.ProcessClientHello < t.serverTimingInfo.WriteServerHello &&
+		0 < t.serverTimingInfo.ProcessClientHello &&
+			t.serverTimingInfo.ProcessClientHello < t.serverTimingInfo.WriteServerHello &&
 			t.serverTimingInfo.WriteServerHello < t.serverTimingInfo.WriteEncryptedExtensions &&
 			t.serverTimingInfo.WriteEncryptedExtensions < t.serverTimingInfo.WriteCertificate &&
 			t.serverTimingInfo.WriteCertificate < t.serverTimingInfo.WriteCertificateVerify &&
 			t.serverTimingInfo.WriteCertificateVerify < t.serverTimingInfo.WriteServerFinished &&
-			t.serverTimingInfo.WriteServerFinished < t.serverTimingInfo.ReadCertificate &&
+			0 < t.serverTimingInfo.ReadCertificate &&
 			t.serverTimingInfo.ReadCertificate < t.serverTimingInfo.ReadCertificateVerify &&
-			t.serverTimingInfo.ReadCertificateVerify < t.serverTimingInfo.ReadClientFinished
+			t.serverTimingInfo.ReadCertificateVerify < t.serverTimingInfo.ReadClientFinished &&
+			t.serverTimingInfo.ReadClientFinished < t.serverTimingInfo.FullProtocol
 
 	clientIsMonotonicallyIncreasing :=
-		t.clientTimingInfo.WriteClientHello < t.clientTimingInfo.ProcessServerHello &&
+		0 < t.clientTimingInfo.WriteClientHello &&
 			t.clientTimingInfo.ProcessServerHello < t.clientTimingInfo.ReadEncryptedExtensions &&
 			t.clientTimingInfo.ReadEncryptedExtensions < t.clientTimingInfo.ReadCertificate &&
 			t.clientTimingInfo.ReadCertificate < t.clientTimingInfo.ReadCertificateVerify &&
 			t.clientTimingInfo.ReadCertificateVerify < t.clientTimingInfo.ReadServerFinished &&
 			t.clientTimingInfo.ReadServerFinished < t.clientTimingInfo.WriteCertificate &&
 			t.clientTimingInfo.WriteCertificate < t.clientTimingInfo.WriteCertificateVerify &&
-			t.clientTimingInfo.WriteCertificateVerify < t.clientTimingInfo.WriteClientFinished
+			t.clientTimingInfo.WriteCertificateVerify < t.clientTimingInfo.WriteClientFinished &&
+			t.clientTimingInfo.WriteClientFinished < t.clientTimingInfo.FullProtocol
 
 	return (serverIsMonotonicallyIncreasing && clientIsMonotonicallyIncreasing)
 }

--- a/src/crypto/tls/tls_cf.go
+++ b/src/crypto/tls/tls_cf.go
@@ -102,6 +102,7 @@ func experimentName(c *Conn) string {
 type CFEventTLS13ClientHandshakeTimingInfo struct {
 	timer                   func() time.Time
 	start                   time.Time
+	total                   time.Time
 	WriteClientHello        time.Duration
 	ProcessServerHello      time.Duration
 	ReadEncryptedExtensions time.Duration
@@ -115,6 +116,7 @@ type CFEventTLS13ClientHandshakeTimingInfo struct {
 
 	WriteKEMCiphertext time.Duration
 	ReadKEMCiphertext  time.Duration
+	FullProtocol       time.Duration
 
 	ExperimentName string
 }
@@ -135,15 +137,20 @@ func (e *CFEventTLS13ClientHandshakeTimingInfo) reset() {
 	e.start = e.timer()
 }
 
+func (e *CFEventTLS13ClientHandshakeTimingInfo) finish() {
+	e.FullProtocol = e.timer().Sub(e.total)
+}
+
 func createTLS13ClientHandshakeTimingInfo(timerFunc func() time.Time) CFEventTLS13ClientHandshakeTimingInfo {
 	timer := time.Now
 	if timerFunc != nil {
 		timer = timerFunc
 	}
-
+	now := timer()
 	return CFEventTLS13ClientHandshakeTimingInfo{
 		timer: timer,
-		start: timer(),
+		start: now,
+		total: now,
 	}
 }
 
@@ -155,6 +162,7 @@ func createTLS13ClientHandshakeTimingInfo(timerFunc func() time.Time) CFEventTLS
 type CFEventTLS13ServerHandshakeTimingInfo struct {
 	timer                    func() time.Time
 	start                    time.Time
+	total                    time.Time
 	ProcessClientHello       time.Duration
 	WriteServerHello         time.Duration
 	WriteEncryptedExtensions time.Duration
@@ -168,6 +176,7 @@ type CFEventTLS13ServerHandshakeTimingInfo struct {
 
 	ReadKEMCiphertext  time.Duration
 	WriteKEMCiphertext time.Duration
+	FullProtocol       time.Duration
 
 	ExperimentName string
 }
@@ -184,15 +193,24 @@ func (e CFEventTLS13ServerHandshakeTimingInfo) elapsedTime() time.Duration {
 	return e.timer().Sub(e.start)
 }
 
+func (e *CFEventTLS13ServerHandshakeTimingInfo) reset() {
+	e.start = e.timer()
+}
+
+func (e *CFEventTLS13ServerHandshakeTimingInfo) finish() {
+	e.FullProtocol = e.timer().Sub(e.total)
+}
+
 func createTLS13ServerHandshakeTimingInfo(timerFunc func() time.Time) CFEventTLS13ServerHandshakeTimingInfo {
 	timer := time.Now
 	if timerFunc != nil {
 		timer = timerFunc
 	}
-
+	now := timer()
 	return CFEventTLS13ServerHandshakeTimingInfo{
 		timer: timer,
-		start: timer(),
+		start: now,
+		total: now,
 	}
 }
 


### PR DESCRIPTION
@claucece pls verify that the resets were inserted in the right position.
The idea is to have a reset inmediately after a peer has received a message from the other peer.

*Please review the order of the timings, mainy in the KEMTLS case.

See https://github.com/claucece/KEMTLS-local-measurements/pull/1

```sh
Client
|--> Write Client Hello       101.392µs 
   Server
   | Receive Client Hello     98.792µs 
   | Write Server Hello       131.945µs 
   | Write Server Enc Exts    153.087µs 
   | Write Server Certificate 165.049µs 
<--| Write Server Cert Verify 301.993µs 
Client
|    Process Server Hello       2.429µs 
|    Receive Server Enc Exts    77.393µs 
|    Receive Server Certificate 85.568µs 
|    Receive Server Cert Verify 477.781µs 
|    Receive Server Finished    479.148µs 
|    Write Client Certificate   0s 
|    Write Client Cert Verify   0s 
|--> Write Client Finished      515.741µs 
   Server
   | Receive Client Certificate 0s 
   | Receive Client Cert Verify 0s 
   | Receive Client Finished    549.793µs 
<--| Write Server Finished    309.795µs 
Client Total time: 1.044744ms 
Server Total time: 911.365µs
```