### PR TITLE
net: Add hooks for HTTP-request header processing

### DIFF
--- a/src/net/cf/cf.go
+++ b/src/net/cf/cf.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Cloudflare, Inc.
+
+package cf
+
+// HeaderProcessor is called at various points while reading the client's
+// request header from the wire.
+type HeaderProcessor interface {
+	// HTTP1RequestLine is called in HTTP/1 on the first line, e.g., "GET
+	// /index.html HTTP/1.1".
+	HTTP1RequestLine(line string)
+	// HTTP1RawHeader is called in HTTP/1 on each header, e.g., "Host:
+	// example.com".
+	HTTP1RawHeader(header []byte)
+	// Header is called in HTTP/1 or HTTP/2 on each header (name, value) pair.
+	// The name is canonicalized.
+	Header(name, value string)
+}
+
+// HeaderProcessorContextKey is the key type for the request processor
+// added to the request context.
+type HeaderProcessorContextKey string

--- a/src/net/cf/cf_test.go
+++ b/src/net/cf/cf_test.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2021 Cloudflare, Inc.
+
+package cf_test
+
+import (
+	"net/cf"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+// Check that, if an HTTP server has a net/http.CFNewHeaderProcessor configured,
+// then the request context propagates a processor.
+func TestHTTP1HeaderProcessor(t *testing.T) {
+	ch := make(chan *testHeaderProcessor)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		k := cf.HeaderProcessorContextKey("cf-header-processor")
+		v := r.Context().Value(k)
+
+		go func() {
+			p, _ := v.(*testHeaderProcessor)
+			ch <- p
+		}()
+	}))
+	ts.Config.CFNewHeaderProcessor = newTestHeaderProcessor
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	p := <-ch
+	if p == nil {
+		t.Fatal("processor not propagated")
+	}
+
+	if p.isHTTP2 {
+		t.Fatal("HTTP/2 was used; expected HTTP/1")
+	}
+
+	wantCallCt := 1 /* request line */ + 2*3 /* three headers, two calls per header */
+	gotCallCt := len(p.callOrder)
+	if gotCallCt != wantCallCt {
+		t.Errorf("unexpected number of calls: got %d; want %d", gotCallCt, wantCallCt)
+	}
+
+	wantCallOrder := []callType{
+		callHTTP1RequestLine,
+		callHTTP1RawHeader,
+		callHeader,
+		callHTTP1RawHeader,
+		callHeader,
+		callHTTP1RawHeader,
+		callHeader,
+	}
+
+	if !reflect.DeepEqual(p.callOrder, wantCallOrder) {
+		t.Errorf("unexpected call order: got %v; want %v", p.callOrder, wantCallOrder)
+	}
+}
+
+// Same test as above, except enable HTTP/2.
+func TestHTTP2HeaderProcessor(t *testing.T) {
+	ch := make(chan *testHeaderProcessor)
+
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		k := cf.HeaderProcessorContextKey("cf-header-processor")
+		v := r.Context().Value(k)
+
+		go func() {
+			p, _ := v.(*testHeaderProcessor)
+			ch <- p
+		}()
+	}))
+	ts.EnableHTTP2 = true
+	ts.Config.CFNewHeaderProcessor = newTestHeaderProcessor
+	ts.StartTLS()
+	defer ts.Close()
+
+	tc := ts.Client()
+	resp, err := tc.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	p := <-ch
+	if p == nil {
+		t.Fatal("processor not propagated")
+	}
+
+	if !p.isHTTP2 {
+		t.Fatal("HTTP/1 was used; expected HTTP/2")
+	}
+
+	wantCallCt := 6 /* six headers */
+	gotCallCt := len(p.callOrder)
+	if gotCallCt != wantCallCt {
+		t.Errorf("unexpected number of calls: got %d; want %d", gotCallCt, wantCallCt)
+	}
+
+	wantCallOrder := []callType{
+		callHeader,
+		callHeader,
+		callHeader,
+		callHeader,
+		callHeader,
+		callHeader,
+	}
+
+	if !reflect.DeepEqual(p.callOrder, wantCallOrder) {
+		t.Errorf("unexpected call order: got %v; want %v", p.callOrder, wantCallOrder)
+	}
+}
+
+// Check that the request context does not propagate a request processor if no
+// constructor is configured.
+func TestNoHeaderProcessor(t *testing.T) {
+	ch := make(chan *testHeaderProcessor)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		k := cf.HeaderProcessorContextKey("cf-header-processor")
+		v := r.Context().Value(k)
+
+		go func() {
+			p, _ := v.(*testHeaderProcessor)
+			ch <- p
+		}()
+	}))
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	p := <-ch
+	if p != nil {
+		t.Fatal("processor propagated; expected nil")
+	}
+}
+
+// This processor records the order in which the calls were made and whether
+// HTTP/2 was used for the request.
+type testHeaderProcessor struct {
+	callOrder []callType
+	isHTTP2   bool
+}
+
+type callType int
+
+func (t callType) String() string {
+	switch t {
+	case callHTTP1RequestLine:
+		return "HTTP1RequestLine"
+	case callHTTP1RawHeader:
+		return "HTTP1RawHeader"
+	case callHeader:
+		return "RawHeader"
+	default:
+		panic("unknown call type")
+	}
+}
+
+const (
+	callHTTP1RequestLine callType = iota
+	callHTTP1RawHeader
+	callHeader
+)
+
+func newTestHeaderProcessor(isHTTP2 bool) cf.HeaderProcessor {
+	return &testHeaderProcessor{
+		isHTTP2: isHTTP2,
+	}
+}
+
+func (p *testHeaderProcessor) HTTP1RequestLine(_ string) {
+	p.callOrder = append(p.callOrder, callHTTP1RequestLine)
+}
+
+func (p *testHeaderProcessor) HTTP1RawHeader(_ []byte) {
+	p.callOrder = append(p.callOrder, callHTTP1RawHeader)
+}
+
+func (p *testHeaderProcessor) Header(_, _ string) {
+	p.callOrder = append(p.callOrder, callHeader)
+}

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -17,6 +17,7 @@ import (
 	"log"
 	"math/rand"
 	"net"
+	"net/cf"
 	"net/textproto"
 	"net/url"
 	urlpkg "net/url"
@@ -959,6 +960,11 @@ func (c *conn) readRequest(ctx context.Context) (w *response, err error) {
 		return nil, ErrHijacked
 	}
 
+	var p cf.HeaderProcessor
+	if newP := c.server.CFNewHeaderProcessor; newP != nil {
+		p = newP(false /* isHTTP2 */)
+	}
+
 	var (
 		wholeReqDeadline time.Time // or zero if none
 		hdrDeadline      time.Time // or zero if none
@@ -983,7 +989,7 @@ func (c *conn) readRequest(ctx context.Context) (w *response, err error) {
 		peek, _ := c.bufr.Peek(4) // ReadRequest will get err below
 		c.bufr.Discard(numLeadingCRorLF(peek))
 	}
-	req, err := readRequest(c.bufr, keepHostHeader)
+	req, err := cfReadRequestWithProcessor(c.bufr, keepHostHeader, p)
 	if err != nil {
 		if c.r.hitReadLimit() {
 			return nil, errTooLarge
@@ -1021,6 +1027,10 @@ func (c *conn) readRequest(ctx context.Context) (w *response, err error) {
 	}
 	delete(req.Header, "Host")
 
+	if p != nil {
+		k := cf.HeaderProcessorContextKey("cf-header-processor")
+		ctx = context.WithValue(ctx, k, p)
+	}
 	ctx, cancelCtx := context.WithCancel(ctx)
 	req.ctx = ctx
 	req.RemoteAddr = c.remoteAddr
@@ -2637,6 +2647,15 @@ type Server struct {
 	// is derived from the base context and has a ServerContextKey
 	// value.
 	ConnContext func(ctx context.Context, c net.Conn) context.Context
+
+	// CFNewHeaderProcessor, if set, is called prior to processing each request
+	// to construct a net/cf.HeaderProcessor. This interface is called while
+	// processing the request to record various features of the headers.
+	//
+	// NOTE: The "CF" prefix denotes that this callback was added to support a
+	// Cloudflare-internal use-case. It may or may not be useful for upstream
+	// Go.
+	CFNewHeaderProcessor func(isHTTP2 bool) cf.HeaderProcessor
 
 	inShutdown atomicBool // true when when server is in shutdown
 


### PR DESCRIPTION
This defines a new interface, net/http.CFRequestProcessor, that is invoked while processing the client's request header from the wire. It allows us to record information about the request  header that is otherwise not exposed by net/http.Request, e.g., the order of the headers.
