### PR TITLE
crypto/tls: Refactor client state machine after draft-ietf-tls-esni upgrade

### DIFF
--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -129,18 +129,8 @@ type Conn struct {
 		greased      bool   // Client greased ECH
 		accepted     bool   // Server accepted ECH
 		retryConfigs []byte // The retry configurations
-
-		// The client's state, used in case of HRR.
-		innerRandom []byte                   // ClientHelloInner.random
-		publicName  string                   // ECHConfig.contents.public_name
-		configId    uint8                    // ECHConfig.contents.key_config.config_id
-		suite       hpkeSymmetricCipherSuite // ClientECH.cipher_suite
-		dummy       []byte                   // serialized ClientECH when greasing ECH
+		configId     uint8  // The config id
 	}
-
-	// Set by the client and server when an HRR message was sent in this
-	// handshake.
-	hrrTriggered bool
 }
 
 // Access to net.Conn methods.

--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -226,7 +226,6 @@ func (c *Conn) clientHandshake() (err error) {
 			serverHello:      serverHello,
 			hello:            hello,
 			helloInner:       helloInner,
-			helloBase:        helloBase,
 			ecdheParams:      ecdheParams,
 			session:          session,
 			earlySecret:      earlySecret,

--- a/src/crypto/tls/handshake_server.go
+++ b/src/crypto/tls/handshake_server.go
@@ -142,7 +142,7 @@ func (c *Conn) readClientHello() (*clientHelloMsg, error) {
 	// or GetCertifciate(). Hence, it is not currently possible to reject ECH if
 	// we don't recognize the inner SNI. This may or may not be desirable in the
 	// future.
-	clientHello, err = c.echAcceptOrReject(clientHello)
+	clientHello, err = c.echAcceptOrReject(clientHello, false) // afterHRR == false
 	if err != nil {
 		return nil, fmt.Errorf("tls: %s", err) // Alert sent.
 	}

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -549,7 +549,6 @@ func (hs *serverHandshakeStateTLS13) sendDummyChangeCipherSpec() error {
 
 func (hs *serverHandshakeStateTLS13) doHelloRetryRequest(selectedGroup CurveID) error {
 	c := hs.c
-	c.hrrTriggered = true
 
 	// The first ClientHello gets double-hashed into the transcript upon a
 	// HelloRetryRequest. See RFC 8446, Section 4.4.1.
@@ -610,7 +609,7 @@ func (hs *serverHandshakeStateTLS13) doHelloRetryRequest(selectedGroup CurveID) 
 		return unexpectedMessageError(clientHello, msg)
 	}
 
-	clientHello, err = c.echAcceptOrReject(clientHello)
+	clientHello, err = c.echAcceptOrReject(clientHello, true) // afterHRR == true
 	if err != nil {
 		return fmt.Errorf("tls: %s", err) // Alert sent
 	}

--- a/src/crypto/tls/hpke.go
+++ b/src/crypto/tls/hpke.go
@@ -12,9 +12,17 @@ import (
 // The mandatory-to-implement HPKE cipher suite for use with the ECH extension.
 var defaultHPKESuite hpke.Suite
 
-const (
-	defaultHPKESuiteTagLen int = 16 // AEAD_AES128GCM
-)
+func init() {
+	var err error
+	defaultHPKESuite, err = hpkeAssembleSuite(
+		uint16(hpke.KEM_X25519_HKDF_SHA256),
+		uint16(hpke.KDF_HKDF_SHA256),
+		uint16(hpke.AEAD_AES128GCM),
+	)
+	if err != nil {
+		panic(fmt.Sprintf("hpke: mandatory-to-implement cipher suite not supported: %s", err))
+	}
+}
 
 func hpkeAssembleSuite(kemId, kdfId, aeadId uint16) (hpke.Suite, error) {
 	kem := hpke.KEM(kemId)
@@ -30,16 +38,4 @@ func hpkeAssembleSuite(kemId, kdfId, aeadId uint16) (hpke.Suite, error) {
 		return hpke.Suite{}, errors.New("AEAD is not supported")
 	}
 	return hpke.NewSuite(kem, kdf, aead), nil
-}
-
-func init() {
-	var err error
-	defaultHPKESuite, err = hpkeAssembleSuite(
-		uint16(hpke.KEM_X25519_HKDF_SHA256),
-		uint16(hpke.KDF_HKDF_SHA256),
-		uint16(hpke.AEAD_AES128GCM),
-	)
-	if err != nil {
-		panic(fmt.Sprintf("hpke: mandatory-to-implement cipher suite not supported: %s", err))
-	}
 }


### PR DESCRIPTION
Based on #89.

Before draft-ietf-tls-esni-11, there was no way for a client that
offered ECH to tell whether a HelloRetryRequest (HRR) was sent by the
client-facing or backend server. Starting in draft-ietf-tls-esni-11
there is an explicit signal of ECH acceptance after HRR. This allows us
to simplify the client state machine.