### PR TITLE
net/http: Preserve some features of headers on the wire

### DIFF
--- a/src/net/http/cf_test.go
+++ b/src/net/http/cf_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2021 Cloudflare, Inc.
+
+// +build !nethttpomithttp2
+
+package http_test
+
+import (
+	"bufio"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCF_HTTP1ReadRequest(t *testing.T) {
+	rawRequest := "GET / HTTP/1.0\r\n" +
+		"Host: blah\r\n" +
+		"\r\n"
+
+	r, err := http.CFReadRequest(bufio.NewReader(strings.NewReader(rawRequest)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []textproto.CFHeaderLine{
+		{
+			Name:                  "Host",
+			Value:                 "blah",
+			HTTP1SpacesAfterColon: 1,
+		},
+	}
+
+	if !reflect.DeepEqual(r.CFHeaderLines, want) {
+		t.Errorf("unexpected CFHeaderLines: want %v; got %v", r.CFHeaderLines, want)
+	}
+}
+
+// Check that http.Request.CFHeaderLines gets set properly.
+func TestCF_HTTP1HeaderLines(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := []textproto.CFHeaderLine{
+			{
+				Name:                  "Host",
+				Value:                 r.Host,
+				HTTP1SpacesAfterColon: 1,
+			},
+			{
+				Name:                  "User-Agent",
+				Value:                 "Go-http-client/1.1",
+				HTTP1SpacesAfterColon: 1,
+			},
+			{
+				Name:                  "Accept-Encoding",
+				Value:                 "gzip",
+				HTTP1SpacesAfterColon: 1,
+			},
+		}
+
+		if !reflect.DeepEqual(r.CFHeaderLines, want) {
+			t.Errorf("unexpected CFHeaderLines: want %v; got %v", r.CFHeaderLines, want)
+		}
+	}))
+	ts.Config.CFRecordRequestLines = true
+	defer ts.Close()
+
+	_, err := http.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Same test as above, except enable HTTP/2.
+func TestCF_HTTP2HeaderLines(t *testing.T) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := []textproto.CFHeaderLine{
+			{
+				Name:                  ":authority",
+				Value:                 r.Host,
+				HTTP1SpacesAfterColon: -1,
+			},
+			{
+				Name:                  ":method",
+				Value:                 "GET",
+				HTTP1SpacesAfterColon: -1,
+			},
+			{
+				Name:                  ":path",
+				Value:                 "/",
+				HTTP1SpacesAfterColon: -1,
+			},
+			{
+				Name:                  ":scheme",
+				Value:                 "https",
+				HTTP1SpacesAfterColon: -1,
+			},
+			{
+				Name:                  "accept-encoding",
+				Value:                 "gzip",
+				HTTP1SpacesAfterColon: -1,
+			},
+			{
+				Name:                  "user-agent",
+				Value:                 "Go-http-client/2.0",
+				HTTP1SpacesAfterColon: -1,
+			},
+		}
+
+		if !reflect.DeepEqual(r.CFHeaderLines, want) {
+			t.Errorf("unexpected CFHeaderLines:\nwant %v\ngot  %v", r.CFHeaderLines, want)
+		}
+
+	}))
+	ts.Config.CFRecordRequestLines = true
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	defer ts.Close()
+
+	tc := ts.Client()
+	_, err := tc.Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/src/net/http/server.go
+++ b/src/net/http/server.go
@@ -983,7 +983,7 @@ func (c *conn) readRequest(ctx context.Context) (w *response, err error) {
 		peek, _ := c.bufr.Peek(4) // ReadRequest will get err below
 		c.bufr.Discard(numLeadingCRorLF(peek))
 	}
-	req, err := readRequest(c.bufr, keepHostHeader)
+	req, err := readRequest(c.bufr, keepHostHeader, c.server.CFRecordRequestLines)
 	if err != nil {
 		if c.r.hitReadLimit() {
 			return nil, errTooLarge
@@ -2637,6 +2637,14 @@ type Server struct {
 	// is derived from the base context and has a ServerContextKey
 	// value.
 	ConnContext func(ctx context.Context, c net.Conn) context.Context
+
+	// CFRecordRequestLines, if set, populates Request.CFRequestLines when
+	// parsing a request.
+	//
+	// NOTE(cjpatton): The "CF" prefix denotes that this feture is used for a
+	// Cloudflare-internal use case. It may or may not be useful for upstream
+	// Goo.
+	CFRecordRequestLines bool
 
 	inShutdown atomicBool // true when when server is in shutdown
 

--- a/src/net/textproto/cf.go
+++ b/src/net/textproto/cf.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 Cloudflare, Inc.
+
+package textproto
+
+// CFHeaderLine represents an HTTP header line in a way that allows headers to
+// be constructed (almost) as they appared on the wire. (We don't keep track of
+// whitespace that interrupts the header value.)
+type CFHeaderLine struct {
+	// Name is the header name as it appears on the wire.
+	Name string
+
+	// Value is the header value.
+	Value string
+
+	// HTTP1SpacesAfterColon is the number of spaces between the colon and the
+	// beginning of the header value. For example, for "Host:     example.com"
+	// we set this to 5.
+	//
+	// This value is propagated by net/http.Request. If HTTP/2 was used for the
+	// request, this value will be set to -1.
+	HTTP1SpacesAfterColon int
+}

--- a/src/net/textproto/cf_test.go
+++ b/src/net/textproto/cf_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Cloudflare, Inc.
+
+package textproto
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCFRadMIMEHeaderr(t *testing.T) {
+	r := reader("my-key: Value one  \r\nlong-kEy:    Even \n Longer Value\r\nmy-KEY:Value two\r\n\n")
+	_, ordered, err := r.CFReadMIMEHeader(true /* recordRequestLines */)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []CFHeaderLine{
+		{
+			Name:                  "my-key",
+			Value:                 "Value one",
+			HTTP1SpacesAfterColon: 1,
+		},
+		{
+			Name:                  "long-kEy",
+			Value:                 "Even Longer Value",
+			HTTP1SpacesAfterColon: 4,
+		},
+		{
+			Name:                  "my-KEY",
+			Value:                 "Value two",
+			HTTP1SpacesAfterColon: 0,
+		},
+	}
+
+	if !reflect.DeepEqual(ordered, want) || err != nil {
+		t.Fatalf("CFReadMIMEHeader: %v, %v; want %v", ordered, err, want)
+	}
+}


### PR DESCRIPTION
Adds a field to net/http.Request that allows us to reconstruct the HTTP headers (almost) as they appeared on the wire.