### PR TITLE
crypto/tls: Reject ECH on invalid encapsulated key

### DIFF
--- a/src/crypto/tls/ech.go
+++ b/src/crypto/tls/ech.go
@@ -298,7 +298,7 @@ func (c *Conn) echAcceptOrReject(hello *clientHelloMsg, afterHRR bool) (*clientH
 			return hello, nil
 		case ECHProviderAbort:
 			c.sendAlert(alert(res.Alert))
-			return nil, fmt.Errorf("ech: %s", err)
+			return nil, fmt.Errorf("ech: provider aborted: %s", res.Error)
 		default:
 			c.sendAlert(alertInternalError)
 			return nil, errors.New("ech: unexpected provider status")
@@ -494,17 +494,17 @@ func echGenerateGreaseExt(rand io.Reader) ([]byte, error) {
 	randomByte := make([]byte, 1)
 	_, err = io.ReadFull(rand, randomByte)
 	if err != nil {
-		return nil, fmt.Errorf("tls: grease ech:: %s", err)
+		return nil, fmt.Errorf("tls: grease ech: %s", err)
 	}
 	ech.handle.configId = randomByte[0]
 	ech.handle.enc, _, err = sender.Setup(rand)
 	if err != nil {
-		return nil, fmt.Errorf("tls: grease ech:: %s", err)
+		return nil, fmt.Errorf("tls: grease ech: %s", err)
 	}
 	ech.payload = make([]byte,
 		int(aead.CipherLen(uint(dummyEncodedHelloInnerLen))))
 	if _, err = io.ReadFull(rand, ech.payload); err != nil {
-		return nil, fmt.Errorf("tls: grease ech:: %s", err)
+		return nil, fmt.Errorf("tls: grease ech: %s", err)
 	}
 	return ech.marshal(), nil
 }

--- a/src/crypto/tls/tls_cf_test.go
+++ b/src/crypto/tls/tls_cf_test.go
@@ -1,6 +1,8 @@
 package tls
 
 import (
+	"circl/hpke"
+	"crypto/rand"
 	"testing"
 )
 
@@ -15,5 +17,51 @@ func TestPropagateCFControl(t *testing.T) {
 	got := s.ConnectionState().CFControl.(*testCFControl).flags
 	if got != want {
 		t.Errorf("failed to propagate CFControl: got %v; want %v", got, want)
+	}
+}
+
+// If the client uses the wrong KEM algorithm to offer ECH, the ECH provider
+// should reject rather than abort. We check for this condition by looking at
+// the error returned by hpke.Receiver.Setup(). This test asserts that the
+// CIRCL's HPKE implementation returns the error we expect.
+func TestCirclHpkeKemAlgorithmMismatchError(t *testing.T) {
+	kem := hpke.KEM_P256_HKDF_SHA256
+	kdf := hpke.KDF_HKDF_SHA256
+	aead := hpke.AEAD_AES128GCM
+	suite := hpke.NewSuite(kem, kdf, aead)
+	_, sk, err := kem.Scheme().GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	incorrectKEM := hpke.KEM_X25519_HKDF_SHA256
+	incorrectSuite := hpke.NewSuite(incorrectKEM, kdf, aead)
+	incorrectPK, _, err := incorrectKEM.Scheme().GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate an encapsulated key share with the incorrect KEM algorithm.
+	incorrectSender, err := incorrectSuite.NewSender(incorrectPK, []byte("some info string"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	incorrectEnc, _, err := incorrectSender.Setup(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attempt to parse an encapsulated key generated using the incorrect KEM
+	// algorithm.
+	receiver, err := suite.NewReceiver(sk, []byte("some info string"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedErrorString := "hpke: invalid KEM public key"
+	if _, err := receiver.Setup(incorrectEnc); err == nil {
+		t.Errorf("expected error; got success")
+	} else if err.Error() != expectedErrorString {
+		t.Errorf("incorrect error string: got '%s'; want '%s'", err, expectedErrorString)
 	}
 }


### PR DESCRIPTION
The ECH provider aborts if it gets an encapsulated key it's unable to parse, causing the ECH server to abort with an "internal_error" alert. This condition can be triggered by a client that generates a GREASE ECH extension with a config_id that happens to match a known config, but uses the incorrect KEM algorithm. This changes the server behavior so that it rejects instead.

The key text from the spec that tells us what to do here is in [Section 7.1 (Client-facing Server Behavior)](https://www.ietf.org/archive/id/draft-ietf-tls-esni-12.html#name-server-behavior): "If decryption fails, the server continues to the next candidate ECHConfig." Being unable to parse the KEM encapsulated key certainly counts as a decryption failure; and because we have exhausted our list of ECH configs, we must reject.

