### PR TITLE
crypto/tls: Upgrade draft-ietf-tls-esni-11 to 12

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -103,8 +103,8 @@ const (
 	extensionSignatureAlgorithmsCert uint16 = 50
 	extensionKeyShare                uint16 = 51
 	extensionRenegotiationInfo       uint16 = 0xff01
-	extensionECH                     uint16 = 0xfe0b // draft-ietf-tls-esni-11
-	extensionECHOuterExtensions      uint16 = 0xfd00 // draft-ietf-tls-esni-11
+	extensionECH                     uint16 = 0xfe0c // draft-ietf-tls-esni-12
+	extensionECHOuterExtensions      uint16 = 0xfd00 // draft-ietf-tls-esni-12
 )
 
 // TLS signaling cipher suite values

--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -129,7 +129,8 @@ type Conn struct {
 		greased      bool   // Client greased ECH
 		accepted     bool   // Server accepted ECH
 		retryConfigs []byte // The retry configurations
-		configId     uint8  // The config id
+		configId     uint8  // The ECH config id
+		maxNameLen   int    // maximum_name_len indicated by the ECH config
 	}
 }
 

--- a/src/crypto/tls/ech_provider.go
+++ b/src/crypto/tls/ech_provider.go
@@ -127,7 +127,7 @@ func (keySet *EXP_ECHKeySet) GetDecryptionContext(rawHandle []byte, version uint
 	res.RetryConfigs = keySet.configs
 
 	// Ensure we know how to proceed, i.e., the caller has indicated a supported
-	// version of ECH. Currently only draft-ietf-tls-esni-11 is supported.
+	// version of ECH. Currently only draft-ietf-tls-esni-12 is supported.
 	if version != extensionECH {
 		res.Status = ECHProviderAbort
 		res.Alert = uint8(alertInternalError)
@@ -204,7 +204,7 @@ func (keySet *EXP_ECHKeySet) GetDecryptionContext(rawHandle []byte, version uint
 //
 // struct {
 //     opaque sk<0..2^16-1>;
-//     ECHConfig config<0..2^16>; // draft-ietf-tls-esni-11
+//     ECHConfig config<0..2^16>; // draft-ietf-tls-esni-12
 // } ECHKey;
 type EXP_ECHKey struct {
 	sk     kem.PrivateKey

--- a/src/crypto/tls/ech_test.go
+++ b/src/crypto/tls/ech_test.go
@@ -90,11 +90,11 @@ Fy/vytRwyjhHuX9ntc5ArCpwbAmY+oW/4w==
 
 // The ECH keys used by the client-facing server.
 const echTestKeys = `-----BEGIN ECH KEYS-----
-ACBScNuuZgB3rYAAwFwIiu88+7u3O132AeajwVOaACPr5QBG/gsAQvUAIAAg3g+Q
-j/4Evd1gjMN/zh4FQgB2qUHBxH1jDMF1cyrvzS0ABAABAAEAE2Nsb3VkZmxhcmUt
-ZXNuaS5jb20AAAAgjrmEl1cAKVdbqQZk24eybJsZFqsPMtfF/1q7oYnu80AAZ/4L
-AGOzABAAQQT1WFJwSj7F90czLHDuG2oNW5rXhUszsd2KDjx6JxPM8HwPLJySTt5V
-tHOQbMbiQR61mLx52GpiKCNFJeCT7NWVAAQAAQABABNjbG91ZGZsYXJlLWVzbmku
+ACB4tkn0JtfTduvavwVASdSbBMYDUUck1MPkK7yVh2rU2ABG/gwAQhQAIAAgEMqr
+0FIiUB4xPxOzpPhb6nWOdk/tqEzFx5Rz6Htw8SYABAABAAElE2Nsb3VkZmxhcmUt
+ZXNuaS5jb20AAAAgXftzLuaXvHdrwMEkYdVF6ZXWs2rL14J25XXAUWytJsUAZ/4M
+AGP4ABAAQQSBp7GpuEgjs0FXL6zm6A1vuFc7G8hM8onq7lixh6FkNbwjNPHOmm7e
+UBsqOKliDuiB0HFm/InFRhWlYhOzRxBoAAQAAQABKhNjbG91ZGZsYXJlLWVzbmku
 Y29tAAA=
 -----END ECH KEYS-----`
 
@@ -109,17 +109,18 @@ AAATY2xvdWRmbGFyZS1lc25pLmNvbQAA
 
 // The sequence of ECH configurations corresponding to echTestKeys.
 const echTestConfigs = `-----BEGIN ECH CONFIGS-----
-AK3+CwBC9QAgACDeD5CP/gS93WCMw3/OHgVCAHapQcHEfWMMwXVzKu/NLQAEAAEA
-AQATY2xvdWRmbGFyZS1lc25pLmNvbQAA/gsAY7MAEABBBPVYUnBKPsX3RzMscO4b
-ag1bmteFSzOx3YoOPHonE8zwfA8snJJO3lW0c5BsxuJBHrWYvHnYamIoI0Ul4JPs
-1ZUABAABAAEAE2Nsb3VkZmxhcmUtZXNuaS5jb20AAA==
+AK3+DABCFAAgACAQyqvQUiJQHjE/E7Ok+FvqdY52T+2oTMXHlHPoe3DxJgAEAAEA
+ASUTY2xvdWRmbGFyZS1lc25pLmNvbQAA/gwAY/gAEABBBIGnsam4SCOzQVcvrObo
+DW+4VzsbyEzyieruWLGHoWQ1vCM08c6abt5QGyo4qWIO6IHQcWb8icVGFaViE7NH
+EGgABAABAAEqE2Nsb3VkZmxhcmUtZXNuaS5jb20AAA==
 -----END ECH CONFIGS-----`
 
 // An invalid sequence of ECH configurations.
 const echTestStaleConfigs = `-----BEGIN ECH CONFIGS-----
-AIz+CwBCAAAgACC0BTukOld/Lw24E1y1Ae6CpyGj/J+GeePXnJQ7CvADegAEAAEA
-AQATY2xvdWRmbGFyZS1lc25pLmNvbQAA/gsAQgAAIAAgvjBnPowjhbhpVpm1px+m
-LSa50fgQyEE4L8IiXNHCiAAABAABAAEAE2Nsb3VkZmxhcmUtZXNuaS5jb20AAA==
+AK3+DABC+wAgACBuArXCr+oOemNd4Gm0jGqCGXNGXyw0nybC4wgJPoE3BQAEAAEA
+AQATY2xvdWRmbGFyZS1lc25pLmNvbQAA/gwAY1cAEABBBMfAn9UTeq+sbIJqNfsZ
+0r+FMLV0yT7o00wx1UNkMcaemXAFSjhbk96UAysPgq5XBy9bNxv8Vux7fba00ExD
+90sABAABAAEAE2Nsb3VkZmxhcmUtZXNuaS5jb20AAA==
 -----END ECH CONFIGS-----`
 
 // echTestProviderAlwaysAbort mocks an ECHProvider that, in response to any
@@ -896,17 +897,17 @@ func TestECHProvider(t *testing.T) {
 	p := echTestLoadKeySet(echTestKeys)
 	t.Run("ok", func(t *testing.T) {
 		handle := []byte{
-			0, 1, 0, 1, 245, 0, 32, 229, 27, 229, 141, 69, 240, 9, 35, 75, 76,
-			171, 120, 67, 143, 151, 186, 127, 71, 25, 191, 196, 253, 49, 172,
-			65, 141, 195, 40, 150, 37, 106, 117,
+			0, 1, 0, 1, 20, 0, 32, 58, 65, 152, 17, 242, 228, 197, 65, 50, 141,
+			192, 238, 191, 189, 66, 135, 216, 221, 241, 116, 130, 74, 16, 120,
+			43, 82, 156, 175, 33, 26, 246, 80,
 		}
 		context := []byte{
-			1, 0, 32, 0, 1, 0, 1, 32, 198, 196, 234, 57, 116, 12, 5, 252, 105,
-			137, 60, 237, 166, 161, 45, 133, 169, 140, 60, 0, 172, 24, 120, 16,
-			36, 62, 159, 97, 19, 234, 254, 152, 16, 104, 245, 85, 178, 38, 194,
-			67, 111, 219, 54, 128, 40, 121, 218, 117, 75, 12, 68, 251, 63, 222,
-			237, 147, 48, 96, 102, 10, 33, 119, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-			0, 0, 0,
+			1, 0, 32, 0, 1, 0, 1, 32, 188, 60, 186, 168, 74, 122, 101, 108, 101,
+			175, 151, 224, 216, 133, 41, 38, 176, 243, 158, 241, 238, 224, 63,
+			54, 36, 209, 55, 185, 130, 243, 98, 102, 16, 224, 243, 140, 134, 61,
+			96, 23, 103, 174, 168, 68, 76, 141, 178, 155, 172, 12, 146, 174,
+			128, 209, 7, 197, 22, 81, 186, 174, 199, 183, 12, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0,
 		}
 		testECHProvider(t, p, handle, extensionECH, ECHProviderResult{
 			Status:       ECHProviderSuccess,

--- a/src/crypto/tls/handshake_messages.go
+++ b/src/crypto/tls/handshake_messages.go
@@ -125,7 +125,7 @@ func (m *clientHelloMsg) marshal() []byte {
 
 		b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 			if len(m.ech) > 0 {
-				// draft-ietf-tls-esni-11, "encrypted_client_hello"
+				// draft-ietf-tls-esni-12, "encrypted_client_hello"
 				b.AddUint16(extensionECH)
 				b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 					b.AddBytes(m.ech)
@@ -418,7 +418,7 @@ func (m *clientHelloMsg) unmarshal(data []byte) bool {
 
 		switch extension {
 		case extensionECH:
-			// draft-ietf-tls-esni-11, "encrypted_client_hello"
+			// draft-ietf-tls-esni-12, "encrypted_client_hello"
 			if len(extData) == 0 ||
 				!extData.ReadBytes(&m.ech, len(extData)) {
 				return false
@@ -761,7 +761,7 @@ func (m *serverHelloMsg) marshal() []byte {
 				})
 			}
 			if len(m.ech) > 0 {
-				// draft-ietf-tls-esni-11, "encrypted_client_hello"
+				// draft-ietf-tls-esni-12, "encrypted_client_hello"
 				b.AddUint16(extensionECH)
 				b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 					b.AddBytes(m.ech)
@@ -878,8 +878,8 @@ func (m *serverHelloMsg) unmarshal(data []byte) bool {
 				return false
 			}
 		case extensionECH:
-			// draft-ietf-tls-esni-11, "encrypted_client_hello"
-			if !extData.ReadBytes(&m.ech, len(extData)) {
+			// draft-ietf-tls-esni-12, "encrypted_client_hello"
+			if !extData.ReadBytes(&m.ech, len(extData)) || len(m.ech) != 8 {
 				return false
 			}
 		default:
@@ -921,7 +921,7 @@ func (m *encryptedExtensionsMsg) marshal() []byte {
 				})
 			}
 			if len(m.ech) > 0 {
-				// draft-ietf-tls-esni-11, "encrypted_client_hello"
+				// draft-ietf-tls-esni-12, "encrypted_client_hello"
 				b.AddUint16(extensionECH)
 				b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 					// If the client-facing server rejects ECH, then it may
@@ -967,7 +967,7 @@ func (m *encryptedExtensionsMsg) unmarshal(data []byte) bool {
 			}
 			m.alpnProtocol = string(proto)
 		case extensionECH:
-			// draft-ietf-tls-esni-11
+			// draft-ietf-tls-esni-12
 			if !extData.ReadBytes(&m.ech, len(extData)) {
 				return false
 			}

--- a/src/crypto/tls/tls.go
+++ b/src/crypto/tls/tls.go
@@ -6,7 +6,7 @@
 // and TLS 1.3, as specified in RFC 8446.
 //
 // This package implements the "Encrypted ClientHello (ECH)" extension, as
-// specified by draft-ietf-tls-esni-11. This extension allows the client to
+// specified by draft-ietf-tls-esni-12. This extension allows the client to
 // encrypt its ClientHello to the public key of an ECH-service provider, known
 // as the client-facing server. If successful, then the client-facing server
 // forwards the decrypted ClientHello to the intended recipient, known as the
@@ -31,7 +31,7 @@ package tls
 // BUG(cjpatton): In order to achieve its security goal, the ECH extension
 // requires padding in order to ensure that the length of handshake messages
 // doesn't depend on who terminates the connection. This package does not yet
-// implement client- or server-side padding: see
+// implement server-side padding: see
 // https://github.com/tlswg/draft-ietf-tls-esni/issues/264.
 
 // BUG(cjpatton): Another goal of the ECH extension is that connections that


### PR DESCRIPTION
Drops support for the previous draft and adds support for the current
one. This change also includes the ClientHelloInner padding scheme
described in Section 6.1.3.