### PR TITLE
crypto/tls: Propagate ClientHello through ConnectionState

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -350,6 +350,13 @@ type ConnectionState struct {
 	// This feature is unstable and applications MUST NOT depend on it.
 	CFControl interface{}
 
+	// CFClientHello is the serialized ClientHello handshake message used by the
+	// connection. It can be empty if the handshake has not concluded.
+	//
+	// NOTE: This feature is used for a Cloudflare-internal functionality. It
+	// is unstable and applications MUST NOT depend on it.
+	CFClientHello []byte
+
 	// ekm is a closure exposed via ExportKeyingMaterial.
 	ekm func(label string, context []byte, length int) ([]byte, error)
 }

--- a/src/crypto/tls/conn.go
+++ b/src/crypto/tls/conn.go
@@ -141,6 +141,9 @@ type Conn struct {
 	// Set by the client and server when an HRR message was sent in this
 	// handshake.
 	hrrTriggered bool
+
+	// The serialized ClientHello used in this connection.
+	clientHello []byte
 }
 
 // Access to net.Conn methods.
@@ -1485,6 +1488,7 @@ func (c *Conn) connectionStateLocked() ConnectionState {
 	state.OCSPResponse = c.ocspResponse
 	state.ECHAccepted = c.ech.accepted
 	state.CFControl = c.config.CFControl
+	state.CFClientHello = c.clientHello
 	if !c.didResume && c.vers != VersionTLS13 {
 		if c.clientFinishedIsFirst {
 			state.TLSUnique = c.clientFinished[:]

--- a/src/crypto/tls/ech_test.go
+++ b/src/crypto/tls/ech_test.go
@@ -831,6 +831,8 @@ func TestECHHandshake(t *testing.T) {
 			if accepted := server.connState.ECHAccepted; accepted != server.serverStatus.Accepted() {
 				t.Errorf("server got ECHAccepted=%v; want %v", accepted, server.serverStatus.Accepted())
 			}
+
+			cfTestClientHelloEqual(t, &client.connState, &server.connState)
 		})
 	}
 }

--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -468,6 +468,7 @@ func (hs *clientHandshakeState) handshake() error {
 		}
 	}
 
+	c.clientHello = hs.hello.marshal()
 	c.ekm = ekmFromMasterSecret(c.vers, hs.suite, hs.masterSecret, hs.hello.random, hs.serverHello.random)
 	atomic.StoreUint32(&c.handshakeStatus, 1)
 

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -152,6 +152,7 @@ func (hs *clientHandshakeStateTLS13) handshake() error {
 		return err
 	}
 
+	c.clientHello = hs.hello.marshal()
 	c.handleCFEvent(hs.handshakeTimings)
 	atomic.StoreUint32(&c.handshakeStatus, 1)
 

--- a/src/crypto/tls/handshake_server.go
+++ b/src/crypto/tls/handshake_server.go
@@ -120,6 +120,7 @@ func (hs *serverHandshakeState) handshake() error {
 		}
 	}
 
+	c.clientHello = hs.clientHello.marshal()
 	c.ekm = ekmFromMasterSecret(c.vers, hs.suite, hs.masterSecret, hs.clientHello.random, hs.hello.random)
 	atomic.StoreUint32(&c.handshakeStatus, 1)
 

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -118,6 +118,7 @@ func (hs *serverHandshakeStateTLS13) handshake() error {
 		return err
 	}
 
+	c.clientHello = hs.clientHello.marshal()
 	c.handleCFEvent(hs.handshakeTimings)
 	atomic.StoreUint32(&c.handshakeStatus, 1)
 

--- a/src/crypto/tls/tls_cf_test.go
+++ b/src/crypto/tls/tls_cf_test.go
@@ -1,6 +1,7 @@
 package tls
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -15,5 +16,26 @@ func TestPropagateCFControl(t *testing.T) {
 	got := s.ConnectionState().CFControl.(*testCFControl).flags
 	if got != want {
 		t.Errorf("failed to propagate CFControl: got %v; want %v", got, want)
+	}
+}
+
+// cfTestClientHelloEqual checks that the client and server both set
+// ConnectionState.CFClientHello and that the values match.
+func cfTestClientHelloEqual(t *testing.T, clientState, serverState *ConnectionState) {
+	cli := clientState.CFClientHello
+	srv := serverState.CFClientHello
+
+	if len(cli) == 0 {
+		t.Fatal("client state is missing CFClientHello")
+	}
+
+	if len(srv) == 0 {
+		t.Fatal("server state is missing CFClientHello")
+	}
+
+	if !bytes.Equal(cli, srv) {
+		t.Error("CFClientHello mismatch")
+		t.Errorf("client: %02x", cli)
+		t.Errorf("server: %02x", srv)
 	}
 }


### PR DESCRIPTION
Adds a field to crypto/tls.ConnectionState containing the serialized
ClientHello used to terminate the connection.
