### PR TITLE
Update CODEOWNERS for src/net

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,4 +3,4 @@ src/circl @armfazh
 src/crypto/tls @claucece @Lekensteyn
 src/crypto/x509 @wbl @cjpatton
 src/internal/cpu @armfazh
-src/net/http @Lekensteyn
+src/net @Lekensteyn @cjpatton


### PR DESCRIPTION
We have made enough changes to net/http that we should have two owners for this package. In addition, we have made changes to other packages in net, so I made myself and @Lekensteyn owners for the whole directory.

* Removes @Lekensteyn as owner of src/net/http
* Adds @Lekensteyn and @cjpatton as owners of src/net