### PR TITLE
crypto/tls: Upgrade draft-ietf-tls-esni-12 to 13

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -103,8 +103,8 @@ const (
 	extensionSignatureAlgorithmsCert uint16 = 50
 	extensionKeyShare                uint16 = 51
 	extensionRenegotiationInfo       uint16 = 0xff01
-	extensionECH                     uint16 = 0xfe0c // draft-ietf-tls-esni-12
-	extensionECHOuterExtensions      uint16 = 0xfd00 // draft-ietf-tls-esni-12
+	extensionECH                     uint16 = 0xfe0d // draft-ietf-tls-esni-13
+	extensionECHOuterExtensions      uint16 = 0xfd00 // draft-ietf-tls-esni-13
 )
 
 // TLS signaling cipher suite values

--- a/src/crypto/tls/ech.go
+++ b/src/crypto/tls/ech.go
@@ -610,7 +610,7 @@ func echEncodeClientHelloInner(innerData []byte, serverNameLen, maxNameLen int) 
 	// Add padding.
 	paddingLen := 0
 	if serverNameLen > 0 {
-		// draft-ietf-tls-esni-12, Section 6.1.3:
+		// draft-ietf-tls-esni-13, Section 6.1.3:
 		//
 		// If the ClientHelloInner contained a "server_name" extension with a
 		// name of length D, add max(0, L - D) bytes of padding.
@@ -618,7 +618,7 @@ func echEncodeClientHelloInner(innerData []byte, serverNameLen, maxNameLen int) 
 			paddingLen += n
 		}
 	} else {
-		// draft-ietf-tls-esni-12, Section 6.1.3:
+		// draft-ietf-tls-esni-13, Section 6.1.3:
 		//
 		// If the ClientHelloInner did not contain a "server_name" extension
 		// (e.g., if the client is connecting to an IP address), add L + 9 bytes
@@ -1005,39 +1005,11 @@ func splitClientHelloExtensions(data []byte) ([]byte, []byte) {
 	return data[:len(data)-len(s)], s
 }
 
-// TODO(cjpatton): draft-ietf-tls-esni-12, Section 4 mandates:
+// TODO(cjpatton): Handle public name as described in draft-ietf-tls-esni-13,
+// Section 4.
 //
-//   Clients MUST ignore any "ECHConfig" structure whose public_name is
-//   not parsable as a dot-separated sequence of LDH labels, as defined
-//   in [RFC5890], Section 2.3.1 or which begins or end with an ASCII
-//   dot.
-//
-//   Clients SHOULD ignore the "ECHConfig" if it contains an encoded
-//   IPv4 address.  To determine if a public_name value is an IPv4
-//   address, clients can invoke the IPv4 parser algorithm in
-//   [WHATWG-IPV4].  It returns a value when the input is an IPv4
-//   address.
-//
-//   See Section 6.1.4.3 for how the client interprets and validates
-//   the public_name.
-//
-// TODO(cjpatton): draft-ietf-tls-esni-12, Section 4.1 mandates:
-//
-//   ECH configuration extensions are used to provide room for additional
-//   functionality as needed.  See Section 12 for guidance on which types
-//   of extensions are appropriate for this structure.
-//
-//   The format is as defined in [RFC8446], Section 4.2.  The same
-//   interpretation rules apply: extensions MAY appear in any order, but
-//   there MUST NOT be more than one extension of the same type in the
-//   extensions block.  An extension can be tagged as mandatory by using
-//   an extension type codepoint with the high order bit set to 1.  A
-//   client that receives a mandatory extension they do not understand
-//   MUST reject the "ECHConfig" content.
-//
-//   Clients MUST parse the extension list and check for unsupported
-//   mandatory extensions.  If an unsupported mandatory extension is
-//   present, clients MUST ignore the "ECHConfig".
+// TODO(cjpatton): Implement ECH config extensions as described in
+// draft-ietf-tls-esni-13, Section 4.1.
 func (c *Config) echSelectConfig() *ECHConfig {
 	for _, echConfig := range c.ClientECHConfigs {
 		if _, err := echConfig.selectSuite(); err == nil &&

--- a/src/crypto/tls/ech_provider.go
+++ b/src/crypto/tls/ech_provider.go
@@ -129,7 +129,7 @@ func (keySet *EXP_ECHKeySet) GetDecryptionContext(rawHandle []byte, version uint
 	res.RetryConfigs = keySet.configs
 
 	// Ensure we know how to proceed, i.e., the caller has indicated a supported
-	// version of ECH. Currently only draft-ietf-tls-esni-12 is supported.
+	// version of ECH. Currently only draft-ietf-tls-esni-13 is supported.
 	if version != extensionECH {
 		res.Status = ECHProviderAbort
 		res.Alert = uint8(alertInternalError)
@@ -217,7 +217,7 @@ func (keySet *EXP_ECHKeySet) GetDecryptionContext(rawHandle []byte, version uint
 //
 // struct {
 //     opaque sk<0..2^16-1>;
-//     ECHConfig config<0..2^16>; // draft-ietf-tls-esni-12
+//     ECHConfig config<0..2^16>; // draft-ietf-tls-esni-13
 // } ECHKey;
 type EXP_ECHKey struct {
 	sk     kem.PrivateKey

--- a/src/crypto/tls/ech_test.go
+++ b/src/crypto/tls/ech_test.go
@@ -90,11 +90,11 @@ Fy/vytRwyjhHuX9ntc5ArCpwbAmY+oW/4w==
 
 // The ECH keys used by the client-facing server.
 const echTestKeys = `-----BEGIN ECH KEYS-----
-ACB4tkn0JtfTduvavwVASdSbBMYDUUck1MPkK7yVh2rU2ABG/gwAQhQAIAAgEMqr
-0FIiUB4xPxOzpPhb6nWOdk/tqEzFx5Rz6Htw8SYABAABAAElE2Nsb3VkZmxhcmUt
-ZXNuaS5jb20AAAAgXftzLuaXvHdrwMEkYdVF6ZXWs2rL14J25XXAUWytJsUAZ/4M
-AGP4ABAAQQSBp7GpuEgjs0FXL6zm6A1vuFc7G8hM8onq7lixh6FkNbwjNPHOmm7e
-UBsqOKliDuiB0HFm/InFRhWlYhOzRxBoAAQAAQABKhNjbG91ZGZsYXJlLWVzbmku
+ACBpvnEYyFK6Ey4Pajbm6VaEsQp4bgRxoPVOs2wOiMuD+QBG/g0AQsMAIAAgCfU+
+VOBXjOut9a9m7wLhrZhHfM0GqE5BQLQK03DJf10ABAABAAElE2Nsb3VkZmxhcmUt
+ZXNuaS5jb20AAAAguffuF8tjWUORwFbQ3+cDDqkMQuuMV7py7p1EJfM9S3IAZ/4N
+AGMDABAAQQRhm1JRi7hkaK1HhcJq4ByJpK4fbsaD65xSqUuW0L53OYK3zEtz78pk
+NhWC9NlkItWc2SYOTrGGHc5WhmJxKCTbAAQAAQABKhNjbG91ZGZsYXJlLWVzbmku
 Y29tAAA=
 -----END ECH KEYS-----`
 
@@ -109,18 +109,18 @@ AAATY2xvdWRmbGFyZS1lc25pLmNvbQAA
 
 // The sequence of ECH configurations corresponding to echTestKeys.
 const echTestConfigs = `-----BEGIN ECH CONFIGS-----
-AK3+DABCFAAgACAQyqvQUiJQHjE/E7Ok+FvqdY52T+2oTMXHlHPoe3DxJgAEAAEA
-ASUTY2xvdWRmbGFyZS1lc25pLmNvbQAA/gwAY/gAEABBBIGnsam4SCOzQVcvrObo
-DW+4VzsbyEzyieruWLGHoWQ1vCM08c6abt5QGyo4qWIO6IHQcWb8icVGFaViE7NH
-EGgABAABAAEqE2Nsb3VkZmxhcmUtZXNuaS5jb20AAA==
+AK3+DQBCwwAgACAJ9T5U4FeM6631r2bvAuGtmEd8zQaoTkFAtArTcMl/XQAEAAEA
+ASUTY2xvdWRmbGFyZS1lc25pLmNvbQAA/g0AYwMAEABBBGGbUlGLuGRorUeFwmrg
+HImkrh9uxoPrnFKpS5bQvnc5grfMS3PvymQ2FYL02WQi1ZzZJg5OsYYdzlaGYnEo
+JNsABAABAAEqE2Nsb3VkZmxhcmUtZXNuaS5jb20AAA==
 -----END ECH CONFIGS-----`
 
 // An invalid sequence of ECH configurations.
 const echTestStaleConfigs = `-----BEGIN ECH CONFIGS-----
-AK3+DABC+wAgACBuArXCr+oOemNd4Gm0jGqCGXNGXyw0nybC4wgJPoE3BQAEAAEA
-AQATY2xvdWRmbGFyZS1lc25pLmNvbQAA/gwAY1cAEABBBMfAn9UTeq+sbIJqNfsZ
-0r+FMLV0yT7o00wx1UNkMcaemXAFSjhbk96UAysPgq5XBy9bNxv8Vux7fba00ExD
-90sABAABAAEAE2Nsb3VkZmxhcmUtZXNuaS5jb20AAA==
+AK3+DQBCfgAgACA02DWuCoykTn5CZ/t+h3dXN2JLS5r5RlJPaOzH1UdnRgAEAAEA
+ASUTY2xvdWRmbGFyZS1lc25pLmNvbQAA/g0AY8YAEABBBIpQ8lWXbmjAgaFg6TDf
+si7tgaTV7fUMbrOZzCyKyIfv/cO872MYb9dvEH1Izu6LtKdGAlmKmu2pxtdpbsSW
+CX0ABAABAAEqE2Nsb3VkZmxhcmUtZXNuaS5jb20AAA==
 -----END ECH CONFIGS-----`
 
 // echTestProviderAlwaysAbort mocks an ECHProvider that, in response to any
@@ -757,13 +757,13 @@ func TestECHHandshake(t *testing.T) {
 
 			if test.expectClientAbort && client.err == nil {
 				t.Error("client succeeds; want abort")
-			} else {
+			} else if client.err != nil {
 				t.Logf("client err: %s", client.err)
 			}
 
 			if test.expectServerAbort && server.err == nil {
 				t.Errorf("server succeeds; want abort")
-			} else {
+			} else if server.err != nil {
 				t.Logf("server err: %s", server.err)
 			}
 
@@ -897,17 +897,17 @@ func TestECHProvider(t *testing.T) {
 	p := echTestLoadKeySet(echTestKeys)
 	t.Run("ok", func(t *testing.T) {
 		handle := []byte{
-			0, 1, 0, 1, 20, 0, 32, 58, 65, 152, 17, 242, 228, 197, 65, 50, 141,
-			192, 238, 191, 189, 66, 135, 216, 221, 241, 116, 130, 74, 16, 120,
-			43, 82, 156, 175, 33, 26, 246, 80,
+			0, 1, 0, 1, 195, 0, 32, 49, 215, 32, 55, 8, 132, 98, 118, 166, 113,
+			184, 40, 196, 151, 103, 20, 221, 148, 22, 72, 112, 152, 18, 20, 107,
+			15, 109, 178, 15, 98, 104, 66,
 		}
 		context := []byte{
-			1, 0, 32, 0, 1, 0, 1, 32, 188, 60, 186, 168, 74, 122, 101, 108, 101,
-			175, 151, 224, 216, 133, 41, 38, 176, 243, 158, 241, 238, 224, 63,
-			54, 36, 209, 55, 185, 130, 243, 98, 102, 16, 224, 243, 140, 134, 61,
-			96, 23, 103, 174, 168, 68, 76, 141, 178, 155, 172, 12, 146, 174,
-			128, 209, 7, 197, 22, 81, 186, 174, 199, 183, 12, 0, 0, 0, 0, 0, 0,
-			0, 0, 0, 0, 0, 0,
+			1, 0, 32, 0, 1, 0, 1, 32, 111, 237, 227, 138, 43, 202, 113, 109,
+			127, 174, 36, 48, 232, 103, 97, 52, 76, 112, 136, 36, 220, 91, 12,
+			21, 63, 194, 77, 110, 112, 25, 241, 135, 16, 214, 55, 95, 236, 101,
+			6, 49, 56, 18, 215, 166, 137, 136, 225, 58, 54, 12, 229, 100, 254,
+			43, 179, 2, 188, 179, 6, 166, 138, 138, 12, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0,
 		}
 		testECHProvider(t, p, handle, extensionECH, ECHProviderResult{
 			Status:       ECHProviderSuccess,

--- a/src/crypto/tls/handshake_messages.go
+++ b/src/crypto/tls/handshake_messages.go
@@ -125,7 +125,7 @@ func (m *clientHelloMsg) marshal() []byte {
 
 		b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 			if len(m.ech) > 0 {
-				// draft-ietf-tls-esni-12, "encrypted_client_hello"
+				// draft-ietf-tls-esni-13, "encrypted_client_hello"
 				b.AddUint16(extensionECH)
 				b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 					b.AddBytes(m.ech)
@@ -418,7 +418,7 @@ func (m *clientHelloMsg) unmarshal(data []byte) bool {
 
 		switch extension {
 		case extensionECH:
-			// draft-ietf-tls-esni-12, "encrypted_client_hello"
+			// draft-ietf-tls-esni-13, "encrypted_client_hello"
 			if len(extData) == 0 ||
 				!extData.ReadBytes(&m.ech, len(extData)) {
 				return false
@@ -761,7 +761,7 @@ func (m *serverHelloMsg) marshal() []byte {
 				})
 			}
 			if len(m.ech) > 0 {
-				// draft-ietf-tls-esni-12, "encrypted_client_hello"
+				// draft-ietf-tls-esni-13, "encrypted_client_hello"
 				b.AddUint16(extensionECH)
 				b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 					b.AddBytes(m.ech)
@@ -878,8 +878,8 @@ func (m *serverHelloMsg) unmarshal(data []byte) bool {
 				return false
 			}
 		case extensionECH:
-			// draft-ietf-tls-esni-12, "encrypted_client_hello"
-			if !extData.ReadBytes(&m.ech, len(extData)) || len(m.ech) != 8 {
+			// draft-ietf-tls-esni-13, "encrypted_client_hello"
+			if !extData.ReadBytes(&m.ech, len(extData)) {
 				return false
 			}
 		default:
@@ -921,7 +921,7 @@ func (m *encryptedExtensionsMsg) marshal() []byte {
 				})
 			}
 			if len(m.ech) > 0 {
-				// draft-ietf-tls-esni-12, "encrypted_client_hello"
+				// draft-ietf-tls-esni-13, "encrypted_client_hello"
 				b.AddUint16(extensionECH)
 				b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
 					// If the client-facing server rejects ECH, then it may
@@ -967,7 +967,7 @@ func (m *encryptedExtensionsMsg) unmarshal(data []byte) bool {
 			}
 			m.alpnProtocol = string(proto)
 		case extensionECH:
-			// draft-ietf-tls-esni-12
+			// draft-ietf-tls-esni-13
 			if !extData.ReadBytes(&m.ech, len(extData)) {
 				return false
 			}

--- a/src/crypto/tls/tls.go
+++ b/src/crypto/tls/tls.go
@@ -6,7 +6,7 @@
 // and TLS 1.3, as specified in RFC 8446.
 //
 // This package implements the "Encrypted ClientHello (ECH)" extension, as
-// specified by draft-ietf-tls-esni-12. This extension allows the client to
+// specified by draft-ietf-tls-esni-13. This extension allows the client to
 // encrypt its ClientHello to the public key of an ECH-service provider, known
 // as the client-facing server. If successful, then the client-facing server
 // forwards the decrypted ClientHello to the intended recipient, known as the
@@ -34,17 +34,11 @@ package tls
 // implement server-side padding: see
 // https://github.com/tlswg/draft-ietf-tls-esni/issues/264.
 
-// BUG(cjpatton): Another goal of the ECH extension is that connections that
-// middleboxes shouldn't differentiate between the real ECH protocol and the
-// "grease ECH" protocol wherein the client generates a dummy ECH extension,
-// which the server is expected to ignore. The ECH specification is subject to
-// change as this "don't stick out" property is worked out in more detail.
-
 // BUG(cjpatton): The interaction of the ECH extension with PSK has not yet been
 // fully vetted. For now, the server disables session tickets if ECH is enabled.
 
 // BUG(cjpatton): Upon ECH rejection, if retry configurations are provided, then
-// the client is expected to retry the connection.  Otherwise, it may regard ECH
+// the client is expected to retry the connection. Otherwise, it may regard ECH
 // as being securely disabled by the client-facing server. The client in this
 // package does not attempt to retry the handshake.
 


### PR DESCRIPTION
Drops support for the previous version of ECH and adds support for the
latest version. Changes include:

* An optional GREASE extension for the acceptance signal in the
  HelloRetryRequest, which is supported by the test server.

* The rules for parsing the "encrypted_client_hello" extension are
  stricter.