### PR TITLE
crypto/tls: Fix nil dereference in greased ECH acceptance signal

### DIFF
--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -595,7 +595,7 @@ func (hs *serverHandshakeStateTLS13) doHelloRetryRequest(selectedGroup CurveID) 
 		// "encrypted_client_hello" extension with a payload of 8 random bytes;
 		// see Section 10.9.4 for details.
 		helloRetryRequest.ech = make([]byte, 8)
-		if _, err := io.ReadFull(c.config.Rand, helloRetryRequest.ech); err != nil {
+		if _, err := io.ReadFull(c.config.rand(), helloRetryRequest.ech); err != nil {
 			c.sendAlert(alertInternalError)
 			return fmt.Errorf("tls: internal error: rng failure: %s", err)
 		}


### PR DESCRIPTION
When greasing the ECH acceptance signal in the HRR, the server uses
`c.config.Rand`, which may be `nil`. This prevents the nil dereference
by using `c.config.rand()`, which first checks if `c.config.Rand ==
nil`'.

This bug was found when interop testing with boringSSL.
