### PR TITLE
tls13: send alert on invalid ECDH share

### DIFF
--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -571,7 +571,9 @@ func (hs *clientHandshakeStateTLS13) establishHandshakeKeys() error {
 			c.sendAlert(alertIllegalParameter)
 			return fmt.Errorf("%s decaps: %w", sk.Scheme().Name(), err)
 		}
-	} else {
+	}
+
+	if sharedKey == nil {
 		c.sendAlert(alertIllegalParameter)
 		return fmt.Errorf("tls: invalid server key share")
 	}


### PR DESCRIPTION
This was a regression compared to upstream.