### PR TITLE
Fix DC implementation

### DIFF
--- a/src/crypto/tls/generate_delegated_credential.go
+++ b/src/crypto/tls/generate_delegated_credential.go
@@ -1,0 +1,125 @@
+// Copyright 2022 Cloudflare, Inc. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+//go:build ignore
+
+// Generate a delegated credential with the given signature scheme, signed with
+// the given x.509 key pair. Outputs to 'dc.cred' and 'dckey.pem' and will
+// overwrite existing files.
+
+// Example usage:
+// generate_delegated_credential -cert-path cert.pem -key-path key.pem -signature-scheme Ed25519 -duration 24h
+
+package main
+
+import (
+	circlSign "circl/sign"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+var (
+	validFor        = flag.Duration("duration", 5*24*time.Hour, "Duration that credential is valid for")
+	signatureScheme = flag.String("signature-scheme", "", "The signature scheme used by the DC")
+	certPath        = flag.String("cert-path", "./cert.pem", "Path to signing cert")
+	keyPath         = flag.String("key-path", "./key.pem", "Path to signing key")
+	isClient        = flag.Bool("client-dc", false, "Create a client Delegated Credential")
+	outPath         = flag.String("out-path", "./", "Path to output directory")
+)
+
+var SigStringMap = map[string]tls.SignatureScheme{
+	// ECDSA algorithms. Only constrained to a specific curve in TLS 1.3.
+	"ECDSAWithP256AndSHA256": tls.ECDSAWithP256AndSHA256,
+	"ECDSAWithP384AndSHA384": tls.ECDSAWithP384AndSHA384,
+	"ECDSAWithP521AndSHA512": tls.ECDSAWithP521AndSHA512,
+
+	// EdDSA algorithms.
+	"Ed25519": tls.Ed25519,
+}
+
+func main() {
+	flag.Parse()
+	sa := SigStringMap[*signatureScheme]
+
+	cert, err := tls.LoadX509KeyPair(*certPath, *keyPath)
+	if err != nil {
+		log.Fatalf("Failed to load certificate and key: %v", err)
+	}
+	cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		log.Fatalf("Failed to parse leaf certificate: %v", err)
+	}
+
+	validTime := time.Since(cert.Leaf.NotBefore) + *validFor
+	dc, priv, err := tls.NewDelegatedCredential(&cert, sa, validTime, *isClient)
+	if err != nil {
+		log.Fatalf("Failed to create a DC: %v\n", err)
+	}
+	dcBytes, err := dc.Marshal()
+	if err != nil {
+		log.Fatalf("Failed to marshal DC: %v\n", err)
+	}
+
+	DCOut, err := os.Create(filepath.Join(*outPath, "dc.cred"))
+	if err != nil {
+		log.Fatalf("Failed to open dc.cred for writing: %v", err)
+	}
+
+	DCOut.Write(dcBytes)
+	if err := DCOut.Close(); err != nil {
+		log.Fatalf("Error closing dc.cred: %v", err)
+	}
+	log.Print("wrote dc.cred\n")
+
+	derBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		log.Fatalf("Failed to marshal DC private key: %v\n", err)
+	}
+
+	DCKeyOut, err := os.Create(filepath.Join(*outPath, "dckey.pem"))
+	if err != nil {
+		log.Fatalf("Failed to open dckey.pem for writing: %v", err)
+	}
+
+	if err := pem.Encode(DCKeyOut, &pem.Block{Type: "PRIVATE KEY", Bytes: derBytes}); err != nil {
+		log.Fatalf("Failed to write data to dckey.pem: %v\n", err)
+	}
+	if err := DCKeyOut.Close(); err != nil {
+		log.Fatalf("Error closing dckey.pem: %v\n", err)
+	}
+	log.Print("wrote dckey.pem\n")
+
+	fmt.Println("Success")
+}
+
+// Copied from tls.go, because it's private.
+func parsePrivateKey(der []byte) (crypto.PrivateKey, error) {
+	if key, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParsePKCS8PrivateKey(der); err == nil {
+		switch key := key.(type) {
+		case *rsa.PrivateKey, *ecdsa.PrivateKey, ed25519.PrivateKey, circlSign.PrivateKey:
+			return key, nil
+		default:
+			return nil, errors.New("tls: found unknown private key type in PKCS#8 wrapping")
+		}
+	}
+	if key, err := x509.ParseECPrivateKey(der); err == nil {
+		return key, nil
+	}
+
+	return nil, errors.New("tls: failed to parse private key")
+}

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -60,7 +60,7 @@ func (hs *clientHandshakeStateTLS13) processDelegatedCredentialFromServer(rawDC 
 			return errors.New("tls: got Delegated Credential extension without indication")
 		}
 
-		dc, err = unmarshalDelegatedCredential(rawDC)
+		dc, err = UnmarshalDelegatedCredential(rawDC)
 		if err != nil {
 			c.sendAlert(alertDecodeError)
 			return fmt.Errorf("tls: Delegated Credential: %s", err)
@@ -69,6 +69,10 @@ func (hs *clientHandshakeStateTLS13) processDelegatedCredentialFromServer(rawDC 
 		if !isSupportedSignatureAlgorithm(dc.cred.expCertVerfAlgo, supportedSignatureAlgorithmsDC) {
 			c.sendAlert(alertIllegalParameter)
 			return errors.New("tls: Delegated Credential used with invalid signature algorithm")
+		}
+		if !isSupportedSignatureAlgorithm(dc.algorithm, c.config.supportedSignatureAlgorithms()) {
+			c.sendAlert(alertIllegalParameter)
+			return errors.New("tls: Delegated Credential signed with unsupported signature algorithm")
 		}
 	}
 
@@ -824,26 +828,21 @@ func certificateRequestInfo(certReq *certificateRequestMsgTLS13, vers uint16, ct
 // cannot be used for the current connection.
 func getClientDelegatedCredential(cri *CertificateRequestInfo, cert *Certificate) (*DelegatedCredentialPair, error) {
 	if len(cert.DelegatedCredentials) == 0 {
-		return nil, errors.New("No Delegated Credential found.")
-	}
-
-	if len(cert.DelegatedCredentials) == 1 {
-		// There's only one choice, so no point doing any work.
-		return &cert.DelegatedCredentials[0], nil
+		return nil, errors.New("no Delegated Credential found")
 	}
 
 	for _, dcPair := range cert.DelegatedCredentials {
 		// If the client sent the signature_algorithms in the DC extension, ensure it supports
 		// schemes we can use with this delegated credential.
 		if len(cri.SignatureSchemesDC) > 0 {
-			if _, err := selectSignatureSchemeDC(VersionTLS13, dcPair.DC, cri.SignatureSchemesDC); err == nil {
+			if _, err := selectSignatureSchemeDC(VersionTLS13, dcPair.DC, cri.SignatureSchemes, cri.SignatureSchemesDC); err == nil {
 				return &dcPair, nil
 			}
 		}
 	}
 
 	// No delegated credential can be returned.
-	return nil, errors.New("No valid Delegated Credential found.")
+	return nil, errors.New("no valid Delegated Credential found")
 }
 
 func (hs *clientHandshakeStateTLS13) sendClientCertificate() error {
@@ -862,11 +861,12 @@ func (hs *clientHandshakeStateTLS13) sendClientCertificate() error {
 
 	var dcPair *DelegatedCredentialPair
 	if hs.certReq.supportDelegatedCredential && len(hs.certReq.supportedSignatureAlgorithmsDC) > 0 {
+		// getClientDelegatedCredential selects a delegated credential that the server has advertised support for, if possible.
 		if delegatedCredentialPair, err := getClientDelegatedCredential(cri, cert); err == nil {
 			if delegatedCredentialPair.DC != nil && delegatedCredentialPair.PrivateKey != nil {
 				var err error
 				// Even if the Delegated Credential has already been marshalled, be sure it is the correct one.
-				if delegatedCredentialPair.DC.raw, err = delegatedCredentialPair.DC.marshal(); err == nil {
+				if delegatedCredentialPair.DC.raw, err = delegatedCredentialPair.DC.Marshal(); err == nil {
 					dcPair = delegatedCredentialPair
 					cert.DelegatedCredential = dcPair.DC.raw
 				}
@@ -908,12 +908,10 @@ func (hs *clientHandshakeStateTLS13) sendClientCertificate() error {
 
 	if certMsg.delegatedCredential {
 		suppSigAlgo = hs.certReq.supportedSignatureAlgorithmsDC
-		sigAlgorithm, err = selectSignatureSchemeDC(c.vers, dcPair.DC, suppSigAlgo)
-		if err != nil {
-			// getDelegatedCredential returned a delegated credential incompatible with the
-			// CertificateRequestInfo supported signature algorithms.
+		if dcPair == nil || dcPair.DC == nil {
 			cert.DelegatedCredential = nil
 		} else {
+			sigAlgorithm = dcPair.DC.cred.expCertVerfAlgo
 			cert.PrivateKey = dcPair.PrivateKey
 		}
 	}


### PR DESCRIPTION
This PR fixes a number of bugs in the DC implementation.
Specifically this addresses Issues #127, #128, #129, and #130. 
It also adds `generate_delegated_credential.go` which provides a tool matching `generate_cert.go` in style, and producing a delegated credential of the specified properties.