### PR TITLE
crypto/tls: add new X25519Kyber768Draft00 code point

### DIFF
--- a/src/crypto/tls/cfkem_test.go
+++ b/src/crypto/tls/cfkem_test.go
@@ -7,28 +7,16 @@ import (
 	"context"
 	"fmt"
 	"testing"
-
-	"github.com/cloudflare/circl/kem"
-	"github.com/cloudflare/circl/kem/hybrid"
 )
 
-func testHybridKEX(t *testing.T, scheme kem.Scheme, clientPQ, serverPQ,
+func testHybridKEX(t *testing.T, curveID CurveID, clientPQ, serverPQ,
 	clientTLS12, serverTLS12 bool) {
 	var clientSelectedKEX *CurveID
 	var retry bool
 
-	rsaCert := Certificate{
-		Certificate: [][]byte{testRSACertificate},
-		PrivateKey:  testRSAPrivateKey,
-	}
-	serverCerts := []Certificate{rsaCert}
-
 	clientConfig := testConfig.Clone()
 	if clientPQ {
-		clientConfig.CurvePreferences = []CurveID{
-			kemSchemeKeyToCurveID(scheme),
-			X25519,
-		}
+		clientConfig.CurvePreferences = []CurveID{curveID, X25519}
 	}
 	clientCFEventHandler := func(ev CFEvent) {
 		switch e := ev.(type) {
@@ -44,15 +32,13 @@ func testHybridKEX(t *testing.T, scheme kem.Scheme, clientPQ, serverPQ,
 
 	serverConfig := testConfig.Clone()
 	if serverPQ {
-		serverConfig.CurvePreferences = []CurveID{
-			kemSchemeKeyToCurveID(scheme),
-			X25519,
-		}
+		serverConfig.CurvePreferences = []CurveID{curveID, X25519}
+	} else {
+		serverConfig.CurvePreferences = []CurveID{X25519}
 	}
 	if serverTLS12 {
 		serverConfig.MaxVersion = VersionTLS12
 	}
-	serverConfig.Certificates = serverCerts
 
 	c, s := localPipe(t)
 	done := make(chan error)
@@ -78,7 +64,7 @@ func testHybridKEX(t *testing.T, scheme kem.Scheme, clientPQ, serverPQ,
 	var expectedRetry bool
 
 	if clientPQ && serverPQ && !clientTLS12 && !serverTLS12 {
-		expectedKEX = kemSchemeKeyToCurveID(scheme)
+		expectedKEX = curveID
 	} else {
 		expectedKEX = X25519
 	}
@@ -86,36 +72,35 @@ func testHybridKEX(t *testing.T, scheme kem.Scheme, clientPQ, serverPQ,
 		expectedRetry = true
 	}
 
-	if clientSelectedKEX == nil {
-		t.Error("No KEX happened?")
-	}
-
-	if *clientSelectedKEX != expectedKEX {
-		t.Errorf("failed to negotiate: expected %d, got %d",
-			expectedKEX, *clientSelectedKEX)
-	}
 	if expectedRetry != retry {
 		t.Errorf("Expected retry=%v, got retry=%v", expectedRetry, retry)
+	}
+	if clientSelectedKEX == nil {
+		t.Error("No KEX happened?")
+	} else if *clientSelectedKEX != expectedKEX {
+		t.Errorf("failed to negotiate: expected %d, got %d",
+			expectedKEX, *clientSelectedKEX)
 	}
 }
 
 func TestHybridKEX(t *testing.T) {
-	run := func(scheme kem.Scheme, clientPQ, serverPQ, clientTLS12, serverTLS12 bool) {
-		t.Run(fmt.Sprintf("%s serverPQ:%v clientPQ:%v serverTLS12:%v clientTLS12:%v", scheme.Name(),
+	run := func(curveID CurveID, clientPQ, serverPQ, clientTLS12, serverTLS12 bool) {
+		t.Run(fmt.Sprintf("%#04x serverPQ:%v clientPQ:%v serverTLS12:%v clientTLS12:%v", uint16(curveID),
 			serverPQ, clientPQ, serverTLS12, clientTLS12), func(t *testing.T) {
-			testHybridKEX(t, scheme, clientPQ, serverPQ, clientTLS12, serverTLS12)
+			testHybridKEX(t, curveID, clientPQ, serverPQ, clientTLS12, serverTLS12)
 		})
 	}
-	for _, scheme := range []kem.Scheme{
-		hybrid.Kyber512X25519(),
-		hybrid.Kyber768X25519(),
-		hybrid.P256Kyber768Draft00(),
+	for _, curveID := range []CurveID{
+		X25519Kyber512Draft00,
+		X25519Kyber768Draft00,
+		X25519Kyber768Draft00Old,
+		P256Kyber768Draft00,
 	} {
-		run(scheme, true, true, false, false)
-		run(scheme, true, false, false, false)
-		run(scheme, false, true, false, false)
-		run(scheme, true, true, true, false)
-		run(scheme, true, true, false, true)
-		run(scheme, true, true, true, true)
+		run(curveID, true, true, false, false)
+		run(curveID, true, false, false, false)
+		run(curveID, false, true, false, false)
+		run(curveID, true, true, true, false)
+		run(curveID, true, true, false, true)
+		run(curveID, true, true, true, true)
 	}
 }

--- a/src/crypto/tls/handshake_client.go
+++ b/src/crypto/tls/handshake_client.go
@@ -136,7 +136,7 @@ func (c *Conn) makeClientHello(minVersion uint16) (*clientHelloMsg, clientKeySha
 
 		curveID := config.curvePreferences()[0]
 		if scheme := curveIdToCirclScheme(curveID); scheme != nil {
-			pk, sk, err := generateKemKeyPair(scheme, config.rand())
+			pk, sk, err := generateKemKeyPair(scheme, curveID, config.rand())
 			if err != nil {
 				return nil, nil, fmt.Errorf("generateKemKeyPair %s: %w",
 					scheme.Name(), err)

--- a/src/crypto/tls/handshake_client_tls13.go
+++ b/src/crypto/tls/handshake_client_tls13.go
@@ -16,8 +16,6 @@ import (
 	"fmt"
 	"hash"
 	"time"
-
-	circlKem "github.com/cloudflare/circl/kem"
 )
 
 type clientHandshakeStateTLS13 struct {
@@ -382,7 +380,7 @@ func (hs *clientHandshakeStateTLS13) processHelloRetryRequest() error {
 			return errors.New("tls: server sent an unnecessary HelloRetryRequest key_share")
 		}
 		if scheme := curveIdToCirclScheme(curveID); scheme != nil {
-			pk, sk, err := generateKemKeyPair(scheme, c.config.rand())
+			pk, sk, err := generateKemKeyPair(scheme, curveID, c.config.rand())
 			if err != nil {
 				c.sendAlert(alertInternalError)
 				return fmt.Errorf("HRR generateKemKeyPair %s: %w",
@@ -610,7 +608,8 @@ func (hs *clientHandshakeStateTLS13) establishHandshakeKeys() error {
 		if err == nil {
 			sharedKey, _ = key.ECDH(peerKey)
 		}
-	} else if sk, ok := hs.keySharePrivate.(circlKem.PrivateKey); ok {
+	} else if key, ok := hs.keySharePrivate.(*kemPrivateKey); ok {
+		sk := key.secretKey
 		sharedKey, err = sk.Scheme().Decapsulate(sk, hs.serverHello.serverShare.data)
 		if err != nil {
 			c.sendAlert(alertIllegalParameter)


### PR DESCRIPTION
* Point tls.X25519Kyber768Draft00 to the new 0x6399 identifier while the old 0xfe31 identifier is available as tls.X25519Kyber768Draft00Old.
* Make sure that the kem.PrivateKey can always be mapped to the CurveID that was linked to it. This is needed since we now have two ID aliasing to the same scheme, and clients need to be able to detect whether the key share presented by the server actually matches the key share that the client originally sent.
* Update tests, add the new identifier and remove unnecessary code.

Link: https://mailarchive.ietf.org/arch/msg/tls/HAWpNpgptl--UZNSYuvsjB-Pc2k/
Link: https://datatracker.ietf.org/doc/draft-tls-westerbaan-xyber768d00/02/
___
The current solution is the cleanest I could come up with. Alternatives considered:
* Create a new implementation of the `kem.Scheme` interface, wrapping the `hybrid.Kyber768X25519()` scheme. I dropped this idea due to the amount of boiler plate code. In the sample below, I already wrapped the scheme, but I would also have to wrap the returned `kem.PrivateKey` and `kem.PublicKey` values since `clientKeySharePrivateCurveID` used their `Scheme()` method to get back the scheme name.
* Alias to the same `hybrid.Kyber768X25519()` scheme. Fails for the same reason as above: I cannot get back to the original code point that was in use.

<details>
<summary>Incomplete wrapper code sample for kem.Scheme</summary>

```go
package tls

import (
	"github.com/cloudflare/circl/kem"
	"github.com/cloudflare/circl/kem/hybrid"
)

// kemProxyScheme implements kem.Scheme, but aliasing it under a different name.
type kemProxyScheme struct {
	name   string
	scheme kem.Scheme
}

// Assert that kemProxyScheme implements kem.Scheme
var _ kem.Scheme = (*kemProxyScheme)(nil)

func (s *kemProxyScheme) Name() string { return s.name }

func (s *kemProxyScheme) GenerateKeyPair() (kem.PublicKey, kem.PrivateKey, error) {
	return s.scheme.GenerateKeyPair()
}
func (s *kemProxyScheme) Encapsulate(pk kem.PublicKey) (ct, ss []byte, err error) {
	return s.scheme.Encapsulate(pk)
}
func (s *kemProxyScheme) Decapsulate(sk kem.PrivateKey, ct []byte) ([]byte, error) {
	return s.scheme.Decapsulate(sk, ct)
}
func (s *kemProxyScheme) UnmarshalBinaryPublicKey(data []byte) (kem.PublicKey, error) {
	return s.scheme.UnmarshalBinaryPublicKey(data)
}
func (s *kemProxyScheme) UnmarshalBinaryPrivateKey(data []byte) (kem.PrivateKey, error) {
	return s.scheme.UnmarshalBinaryPrivateKey(data)
}
func (s *kemProxyScheme) CiphertextSize() int { return s.scheme.CiphertextSize() }
func (s *kemProxyScheme) SharedKeySize() int  { return s.scheme.SharedKeySize() }
func (s *kemProxyScheme) PrivateKeySize() int { return s.scheme.PrivateKeySize() }
func (s *kemProxyScheme) PublicKeySize() int  { return s.scheme.PublicKeySize() }
func (s *kemProxyScheme) DeriveKeyPair(seed []byte) (kem.PublicKey, kem.PrivateKey) {
	return s.scheme.DeriveKeyPair(seed)
}
func (s *kemProxyScheme) SeedSize() int { return s.scheme.SeedSize() }
func (s *kemProxyScheme) EncapsulateDeterministically(pk kem.PublicKey, seed []byte) (ct, ss []byte, err error) {
	return s.scheme.EncapsulateDeterministically(pk, seed)
}
func (s *kemProxyScheme) EncapsulationSeedSize() int { return s.scheme.EncapsulationSeedSize() }

var hybridKyber768X25519Old = &kemProxyScheme{
	"Kyber768-X25519Old",
	hybrid.Kyber768X25519(),
}
```
</details>