### PR TITLE
Use server's preferred key agreeement (take 2)

### DIFF
--- a/src/crypto/tls/handshake_server_test.go
+++ b/src/crypto/tls/handshake_server_test.go
@@ -1930,6 +1930,7 @@ func TestAESCipherReorderingTLS13(t *testing.T) {
 					supportedVersions:  []uint16{VersionTLS13},
 					compressionMethods: []uint8{compressionNone},
 					keyShares:          []keyShare{{group: X25519, data: pk.PublicKey().Bytes()}},
+					supportedCurves:    []CurveID{X25519},
 				},
 			}
 

--- a/src/crypto/tls/handshake_server_tls13.go
+++ b/src/crypto/tls/handshake_server_tls13.go
@@ -271,14 +271,6 @@ GroupSelection:
 				break GroupSelection
 			}
 		}
-
-		// supported_groups is not necessarily sent
-		for _, ks := range hs.clientHello.keyShares {
-			if ks.group == preferredGroup {
-				selectedGroup = ks.group
-				break GroupSelection
-			}
-		}
 	}
 	if selectedGroup == 0 {
 		c.sendAlert(alertHandshakeFailure)


### PR DESCRIPTION
In contrast to upstream Go, we will send an HelloRetryRequest and accept an extra roundtrip if there is a more preferred group, than the one the client has provided a keyshare for in the initial ClientHello.

Cf. https://datatracker.ietf.org/doc/draft-davidben-tls-key-share-prediction/

Supersedes #157 