### PR TITLE
tls: add eddilithium2 support and fix eddilithium3

### DIFF
--- a/src/crypto/tls/common.go
+++ b/src/crypto/tls/common.go
@@ -190,6 +190,7 @@ const (
 	signatureRSAPSS
 	signatureECDSA
 	signatureEd25519
+	signatureEdDilithium2
 	signatureEdDilithium3
 )
 

--- a/src/crypto/tls/tls_cf.go
+++ b/src/crypto/tls/tls_cf.go
@@ -6,6 +6,7 @@ package tls
 import (
 	circlPki "github.com/cloudflare/circl/pki"
 	circlSign "github.com/cloudflare/circl/sign"
+	"github.com/cloudflare/circl/sign/eddilithium2"
 	"github.com/cloudflare/circl/sign/eddilithium3"
 )
 
@@ -20,6 +21,7 @@ var circlSchemes = [...]struct {
 	sigType uint8
 	scheme  circlSign.Scheme
 }{
+	{signatureEdDilithium2, eddilithium2.Scheme()},
 	{signatureEdDilithium3, eddilithium3.Scheme()},
 }
 

--- a/src/crypto/tls/tls_cf_circl_test.go
+++ b/src/crypto/tls/tls_cf_circl_test.go
@@ -13,11 +13,11 @@ import (
 	"time"
 
 	"github.com/cloudflare/circl/sign"
-	"github.com/cloudflare/circl/sign/eddilithium3"
+	"github.com/cloudflare/circl/sign/eddilithium2"
 )
 
 func TestPQSignatureSchemes(t *testing.T) {
-	pqCert := createPQCert(t, eddilithium3.Scheme())
+	pqCert := createPQCert(t, eddilithium2.Scheme())
 	rsaCert := Certificate{
 		Certificate: [][]byte{testRSACertificate},
 		PrivateKey:  testRSAPrivateKey,
@@ -47,13 +47,13 @@ func TestPQSignatureSchemes(t *testing.T) {
 			clientPQ:           true,
 			serverPQ:           false,
 			serverCerts:        pqAndRsaCerts,
-			expectedCertSigAlg: x509.PureEdDilithium3,
+			expectedCertSigAlg: x509.PureEdDilithium2,
 		},
 		{
 			clientPQ:           true,
 			serverPQ:           true,
 			serverCerts:        pqAndRsaCerts,
-			expectedCertSigAlg: x509.PureEdDilithium3,
+			expectedCertSigAlg: x509.PureEdDilithium2,
 		},
 		{
 			clientPQ:           true,

--- a/src/crypto/x509/x509.go
+++ b/src/crypto/x509/x509.go
@@ -241,6 +241,7 @@ const (
 	SHA384WithRSAPSS
 	SHA512WithRSAPSS
 	PureEd25519
+	PureEdDilithium2
 	PureEdDilithium3
 )
 
@@ -270,6 +271,7 @@ const (
 	DSA // Only supported for parsing.
 	ECDSA
 	Ed25519
+	EdDilithium2
 	EdDilithium3
 )
 
@@ -278,7 +280,8 @@ var publicKeyAlgoName = [...]string{
 	DSA:          "DSA",
 	ECDSA:        "ECDSA",
 	Ed25519:      "Ed25519",
-	EdDilithium3: "Ed25519-Dilithium3",
+	EdDilithium2: "Ed25519-Dilithium2",
+	EdDilithium3: "Ed448-Dilithium3",
 }
 
 func (algo PublicKeyAlgorithm) String() string {

--- a/src/crypto/x509/x509_cf.go
+++ b/src/crypto/x509/x509_cf.go
@@ -7,6 +7,7 @@ import (
 	circlPki "github.com/cloudflare/circl/pki"
 	circlSign "github.com/cloudflare/circl/sign"
 	"github.com/cloudflare/circl/sign/eddilithium3"
+	"github.com/cloudflare/circl/sign/eddilithium2"
 )
 
 // To add a signature scheme from Circl
@@ -21,6 +22,7 @@ var circlSchemes = [...]struct {
 	alg    PublicKeyAlgorithm
 	scheme circlSign.Scheme
 }{
+	{PureEdDilithium2, EdDilithium2, eddilithium2.Scheme()},
 	{PureEdDilithium3, EdDilithium3, eddilithium3.Scheme()},
 }
 


### PR DESCRIPTION
Closes #175

We didn't move from eddilithium3 to eddilithium2 when dilithium3 was renamed to dilithium3.